### PR TITLE
Add NCE-PLRec

### DIFF
--- a/recbole/model/general_recommender/__init__.py
+++ b/recbole/model/general_recommender/__init__.py
@@ -11,6 +11,7 @@ from recbole.model.general_recommender.macridvae import MacridVAE
 from recbole.model.general_recommender.multidae import MultiDAE
 from recbole.model.general_recommender.multivae import MultiVAE
 from recbole.model.general_recommender.nais import NAIS
+from recbole.model.general_recommender.nceplrec import NCEPLRec
 from recbole.model.general_recommender.neumf import NeuMF
 from recbole.model.general_recommender.ngcf import NGCF
 from recbole.model.general_recommender.pop import Pop

--- a/recbole/model/general_recommender/nceplrec.py
+++ b/recbole/model/general_recommender/nceplrec.py
@@ -2,6 +2,10 @@ r"""
 NCE-PLRec
 ################################################
 Reference:
+    Ga Wu, et al. "Noise Contrastive Estimation for One-Class Collaborative Filtering" in Sigir 2019.
+
+Reference code:
+    https://github.com/wuga214/NCE_Projected_LRec
 """
 
 
@@ -69,9 +73,8 @@ class NCEPLRec(GeneralRecommender):
 
         # instead of computing and storing the entire score matrix, just store Q and W and compute the scores on demand
 
-        # torch doesn't support sparse tensor slicing, so will do everything with np/scipy
-        self.user_embeddings = Q
-        self.item_embeddings = W
+        self.user_embeddings = torch.from_numpy(Q)
+        self.item_embeddings = torch.from_numpy(W)
 
     def forward(self):
         pass
@@ -80,13 +83,13 @@ class NCEPLRec(GeneralRecommender):
         return torch.nn.Parameter(torch.zeros(1))
 
     def predict(self, interaction):
-        user = interaction[self.USER_ID].cpu().numpy()
-        item = interaction[self.ITEM_ID].cpu().numpy()
+        user = interaction[self.USER_ID]
+        item = interaction[self.ITEM_ID]
 
-        return torch.from_numpy((self.user_embeddings[user, :] * self.item_embeddings[:, item].T).sum(axis=1))
+        return (self.user_embeddings[user, :] * self.item_embeddings[:, item].T).sum(axis=1)
 
     def full_sort_predict(self, interaction):
-        user = interaction[self.USER_ID].cpu().numpy()
+        user = interaction[self.USER_ID]
 
         r = self.user_embeddings[user, :] @ self.item_embeddings
-        return torch.from_numpy(r.flatten())
+        return r.flatten()

--- a/recbole/model/general_recommender/nceplrec.py
+++ b/recbole/model/general_recommender/nceplrec.py
@@ -69,7 +69,8 @@ class NCEPLRec(GeneralRecommender):
         V_star = Vt.T @ sqrt_Sigma
 
         Q = R @ V_star
-        W = np.linalg.inv(Q.T @ Q + reg_weight * np.identity(rank)) @ Q.T @ R
+        # Vt.shape[0] instead of rank for cases when the interaction matrix is smaller than given rank
+        W = np.linalg.inv(Q.T @ Q + reg_weight * np.identity(Vt.shape[0])) @ Q.T @ R
 
         # instead of computing and storing the entire score matrix, just store Q and W and compute the scores on demand
 

--- a/recbole/model/general_recommender/nceplrec.py
+++ b/recbole/model/general_recommender/nceplrec.py
@@ -1,0 +1,92 @@
+r"""
+NCE-PLRec
+################################################
+Reference:
+"""
+
+
+from recbole.utils.enum_type import ModelType
+import numpy as np
+import scipy.sparse as sp
+import torch
+from sklearn.utils.extmath import randomized_svd
+
+from recbole.utils import InputType
+from recbole.model.abstract_recommender import GeneralRecommender
+
+
+class NCEPLRec(GeneralRecommender):
+    input_type = InputType.POINTWISE
+    type = ModelType.TRADITIONAL
+
+    def __init__(self, config, dataset):
+        super().__init__(config, dataset)
+
+        # need at least one param
+        self.dummy_param = torch.nn.Parameter(torch.zeros(1))
+
+        R = dataset.inter_matrix(
+            form='csr').astype(np.float32)
+
+        beta = config['beta']
+        rank = int(config['rank'])
+        reg_weight = config['reg_weight']
+        seed = config['seed']
+
+        # just directly calculate the entire score matrix in init
+        # (can't be done incrementally)
+        num_users, num_items = R.shape
+
+        item_popularities = R.sum(axis=0)
+
+        D_rows = []
+        for i in range(num_users):
+            row_index, col_index = R[i].nonzero()
+            if len(row_index) > 0:
+                values = item_popularities[:, col_index].getA1()
+                # note this is a slight variation of what's in the paper, for convenience
+                # see https://github.com/wuga214/NCE_Projected_LRec/issues/38
+                values = np.maximum(
+                    np.log(num_users/np.power(values, beta)), 0)
+                D_rows.append(sp.coo_matrix(
+                    (values, (row_index, col_index)), shape=(1, num_items)))
+            else:
+                D_rows.append(sp.coo_matrix((1, num_items)))
+
+        D = sp.vstack(D_rows)
+
+        _, sigma, Vt = randomized_svd(D, n_components=rank,
+                                      n_iter='auto',
+                                      power_iteration_normalizer='QR',
+                                      random_state=seed)
+
+        sqrt_Sigma = np.diag(np.power(sigma, 1/2))
+
+        V_star = Vt.T @ sqrt_Sigma
+
+        Q = R @ V_star
+        W = np.linalg.inv(Q.T @ Q + reg_weight * np.identity(rank)) @ Q.T @ R
+
+        # instead of computing and storing the entire score matrix, just store Q and W and compute the scores on demand
+
+        # torch doesn't support sparse tensor slicing, so will do everything with np/scipy
+        self.user_embeddings = Q
+        self.item_embeddings = W
+
+    def forward(self):
+        pass
+
+    def calculate_loss(self, interaction):
+        return torch.nn.Parameter(torch.zeros(1))
+
+    def predict(self, interaction):
+        user = interaction[self.USER_ID].cpu().numpy()
+        item = interaction[self.ITEM_ID].cpu().numpy()
+
+        return torch.from_numpy((self.user_embeddings[user, :] * self.item_embeddings[:, item].T).sum(axis=1))
+
+    def full_sort_predict(self, interaction):
+        user = interaction[self.USER_ID].cpu().numpy()
+
+        r = self.user_embeddings[user, :] @ self.item_embeddings
+        return torch.from_numpy(r.flatten())

--- a/recbole/properties/model/NCEPLRec.yaml
+++ b/recbole/properties/model/NCEPLRec.yaml
@@ -1,0 +1,3 @@
+beta: 1.0
+rank: 450
+reg_weight: 15000

--- a/run_test_example.py
+++ b/run_test_example.py
@@ -146,6 +146,10 @@ test_examples = {
         'model': 'MacridVAE',
         'dataset': 'ml-100k',
     },
+    'Test NCEPLRec': {
+        'model': 'NCEPLRec',
+        'dataset': 'ml-100k',
+    },
 
     # Context-aware Recommendation
     'Test FM': {

--- a/tests/model/test_model_auto.py
+++ b/tests/model/test_model_auto.py
@@ -168,6 +168,12 @@ class TestGeneralRecommender(unittest.TestCase):
         }
         quick_test(config_dict)
 
+    def test_nceplrec(self):
+        config_dict = {
+            'model': 'NCEPLRec',
+        }
+        quick_test(config_dict)
+
 class TestContextRecommender(unittest.TestCase):
     # todo: more complex context information should be test, such as criteo dataset
 


### PR DESCRIPTION
From "Noise Contrastive Estimation for One-Class Collaborative Filtering" http://www.cs.toronto.edu/~mvolkovs/fp046-wuA.pdf

Repo:
https://github.com/wuga214/NCE_Projected_LRec

Essentially: reweights the interaction matrix with respect to item popularity, does randomized SVD factorization, and then uses the user representations from that for L2-regularized linear regression with a closed-form representation (like EASE) to predict item interactions.

There is a variant in the paper which allows for "non-uniform weighting of users and items". They don't test that method nor implement it in their code, so neither did I.

Performs very well on `ml-100k` in my testing