### PR TITLE
Add C-EASE and ADD-EASE

### DIFF
--- a/recbole/model/general_recommender/__init__.py
+++ b/recbole/model/general_recommender/__init__.py
@@ -1,4 +1,5 @@
 from recbole.model.general_recommender.bpr import BPR
+from recbole.model.general_recommender.cease import CEASE
 from recbole.model.general_recommender.convncf import ConvNCF
 from recbole.model.general_recommender.dgcf import DGCF
 from recbole.model.general_recommender.dmf import DMF

--- a/recbole/model/general_recommender/__init__.py
+++ b/recbole/model/general_recommender/__init__.py
@@ -1,3 +1,4 @@
+from recbole.model.general_recommender.addease import ADDEASE
 from recbole.model.general_recommender.bpr import BPR
 from recbole.model.general_recommender.cease import CEASE
 from recbole.model.general_recommender.convncf import ConvNCF

--- a/recbole/model/general_recommender/addease.py
+++ b/recbole/model/general_recommender/addease.py
@@ -1,0 +1,124 @@
+
+r"""
+ADD-EASE
+################################################
+Reference:
+    Olivier Jeunen, et al. "Closed-Form Models for Collaborative Filtering with Side-Information".
+
+Reference code:
+    https://github.com/olivierjeunen/ease-side-info-recsys-2020/
+"""
+
+
+from recbole.utils.enum_type import ModelType, FeatureType
+import numpy as np
+import scipy.sparse as sp
+import torch
+
+from recbole.utils import InputType
+from recbole.model.abstract_recommender import GeneralRecommender
+
+from sklearn.preprocessing import MultiLabelBinarizer, OneHotEncoder
+
+
+def encode_categorical_item_features(dataset, included_features):
+    item_features = dataset.get_item_feature()
+
+    mlb = MultiLabelBinarizer(sparse_output=True)
+    ohe = OneHotEncoder(sparse=True)
+
+    encoded_feats = []
+
+    for feat in included_features:
+        t = dataset.field2type[feat]
+        feat_frame = item_features[feat].numpy()
+
+        if t == FeatureType.TOKEN:
+            encoded = ohe.fit_transform(feat_frame.reshape(-1, 1))
+            encoded_feats.append(encoded)
+        elif t == FeatureType.TOKEN_SEQ:
+            encoded = mlb.fit_transform(feat_frame)
+
+            # drop first column which corresponds to the padding 0; real categories start at 1
+            # convert to csc first?
+            encoded = encoded[:, 1:]
+            encoded_feats.append(encoded)
+        else:
+            raise Warning(
+                f'ADD-EASE only supports token or token_seq types. [{feat}] is of type [{t}].')
+
+    if not encoded_feats:
+        raise ValueError(
+            f'No valid token or token_seq features to include.')
+
+    return sp.hstack(encoded_feats).T.astype(np.float32)
+
+
+def ease_like(M, reg_weight):
+    # gram matrix
+    G = M.T @ M
+
+    # add reg to diagonal
+    G += reg_weight * sp.identity(G.shape[0])
+
+    # convert to dense because inverse will be dense
+    G = G.todense()
+
+    # invert. this takes most of the time
+    P = np.linalg.inv(G)
+    B = P / (-np.diag(P))
+    # zero out diag
+    np.fill_diagonal(B, 0.)
+
+    return B
+
+
+class ADDEASE(GeneralRecommender):
+    input_type = InputType.POINTWISE
+    type = ModelType.TRADITIONAL
+
+    def __init__(self, config, dataset):
+        super().__init__(config, dataset)
+
+        # need at least one param
+        self.dummy_param = torch.nn.Parameter(torch.zeros(1))
+
+        inter_matrix = dataset.inter_matrix(
+            form='csr').astype(np.float32)
+
+        item_feat_proportion = config['item_feat_proportion']
+        inter_reg_weight = config['inter_reg_weight']
+        item_reg_weight = config['item_reg_weight']
+        included_features = config['included_features']
+
+        tag_item_matrix = encode_categorical_item_features(
+            dataset, included_features)
+
+        inter_S = ease_like(inter_matrix, inter_reg_weight)
+        item_S = ease_like(tag_item_matrix, item_reg_weight)
+
+        # instead of computing and storing the entire score matrix, just store B and compute the scores on demand
+        # more memory efficient for a larger number of users
+
+        # torch doesn't support sparse tensor slicing, so will do everything with np/scipy
+        self.item_similarity = (1-item_feat_proportion) * \
+            inter_S + item_feat_proportion * item_S
+        self.interaction_matrix = inter_matrix
+
+    def forward(self):
+        pass
+
+    def calculate_loss(self, interaction):
+        return torch.nn.Parameter(torch.zeros(1))
+
+    def predict(self, interaction):
+        user = interaction[self.USER_ID].cpu().numpy()
+        item = interaction[self.ITEM_ID].cpu().numpy()
+
+        return torch.from_numpy((self.interaction_matrix[user, :].multiply(self.item_similarity[:, item].T)).sum(axis=1).getA1())
+
+    def full_sort_predict(self, interaction):
+        user = interaction[self.USER_ID].cpu().numpy()
+
+        r = self.interaction_matrix[user, :] @ self.item_similarity
+        return torch.from_numpy(r.flatten())

--- a/recbole/model/general_recommender/addease.py
+++ b/recbole/model/general_recommender/addease.py
@@ -21,7 +21,7 @@ from recbole.model.abstract_recommender import GeneralRecommender
 from sklearn.preprocessing import MultiLabelBinarizer, OneHotEncoder
 
 
-def encode_categorical_item_features(dataset, included_features):
+def encode_categorical_item_features(dataset, selected_features):
     item_features = dataset.get_item_feature()
 
     mlb = MultiLabelBinarizer(sparse_output=True)
@@ -29,7 +29,7 @@ def encode_categorical_item_features(dataset, included_features):
 
     encoded_feats = []
 
-    for feat in included_features:
+    for feat in selected_features:
         t = dataset.field2type[feat]
         feat_frame = item_features[feat].numpy()
 
@@ -89,10 +89,10 @@ class ADDEASE(GeneralRecommender):
         item_feat_proportion = config['item_feat_proportion']
         inter_reg_weight = config['inter_reg_weight']
         item_reg_weight = config['item_reg_weight']
-        included_features = config['included_features']
+        selected_features = config['selected_features']
 
         tag_item_matrix = encode_categorical_item_features(
-            dataset, included_features)
+            dataset, selected_features)
 
         inter_S = ease_like(inter_matrix, inter_reg_weight)
         item_S = ease_like(tag_item_matrix, item_reg_weight)

--- a/recbole/model/general_recommender/cease.py
+++ b/recbole/model/general_recommender/cease.py
@@ -45,13 +45,32 @@ def encode_categorical_item_features(dataset, included_features):
             encoded_feats.append(encoded)
         else:
             raise Warning(
-                f'CEASE/A-EASE only supports token or token_seq types. [{feat}] is of type [{t}].')
+                f'CEASE only supports token or token_seq types. [{feat}] is of type [{t}].')
 
     if not encoded_feats:
         raise ValueError(
             f'No valid token or token_seq features to include.')
 
     return sp.hstack(encoded_feats).T.astype(np.float32)
+
+
+def ease_like(M, reg_weight):
+    # gram matrix
+    G = M.T @ M
+
+    # add reg to diagonal
+    G += reg_weight * sp.identity(G.shape[0])
+
+    # convert to dense because inverse will be dense
+    G = G.todense()
+
+    # invert. this takes most of the time
+    P = np.linalg.inv(G)
+    B = P / (-np.diag(P))
+    # zero out diag
+    np.fill_diagonal(B, 0.)
+
+    return B
 
 
 class CEASE(GeneralRecommender):
@@ -64,46 +83,28 @@ class CEASE(GeneralRecommender):
         # need at least one param
         self.dummy_param = torch.nn.Parameter(torch.zeros(1))
 
-        B = dataset.inter_matrix(
+        inter_matrix = dataset.inter_matrix(
             form='csr').astype(np.float32)
 
         item_feat_weight = config['item_feat_weight']
         reg_weight = config['reg_weight']
         included_features = config['included_features']
 
-        T = encode_categorical_item_features(dataset, included_features)
-        T *= item_feat_weight
+        tag_item_matrix = item_feat_weight * encode_categorical_item_features(dataset, included_features)
 
         # just directly calculate the entire score matrix in init
         # (can't be done incrementally)
 
-        X = sp.vstack([B, T]).tocsr()
+        X = sp.vstack([inter_matrix, tag_item_matrix]).tocsr()
 
-        # gram matrix
-        G = X.T @ X
-
-        # add reg to diagonal
-        G += reg_weight * sp.identity(G.shape[0])
-
-        # convert to dense because inverse will be dense
-        G = G.todense()
-
-        # invert. this takes most of the time
-        P = np.linalg.inv(G)
-        B = P / (-np.diag(P))
-        # zero out diag
-        np.fill_diagonal(B, 0.)
+        item_similarity = ease_like(X, reg_weight)
 
         # instead of computing and storing the entire score matrix, just store B and compute the scores on demand
         # more memory efficient for a larger number of users
-        # but if there's a large number of items not much one can do:
-        # still have to compute B all at once
-        # S = X @ B
-        # self.score_matrix = torch.from_numpy(S).to(self.device)
 
         # torch doesn't support sparse tensor slicing, so will do everything with np/scipy
-        self.item_similarity = B
-        self.interaction_tag_matrix = X
+        self.item_similarity = item_similarity
+        self.interaction_matrix = inter_matrix
 
     def forward(self):
         pass
@@ -115,10 +116,10 @@ class CEASE(GeneralRecommender):
         user = interaction[self.USER_ID].cpu().numpy()
         item = interaction[self.ITEM_ID].cpu().numpy()
 
-        return torch.from_numpy((self.interaction_tag_matrix[user, :].multiply(self.item_similarity[:, item].T)).sum(axis=1).getA1())
+        return torch.from_numpy((self.interaction_matrix[user, :].multiply(self.item_similarity[:, item].T)).sum(axis=1).getA1())
 
     def full_sort_predict(self, interaction):
         user = interaction[self.USER_ID].cpu().numpy()
 
-        r = self.interaction_tag_matrix[user, :] @ self.item_similarity
+        r = self.interaction_matrix[user, :] @ self.item_similarity
         return torch.from_numpy(r.flatten())

--- a/recbole/model/general_recommender/cease.py
+++ b/recbole/model/general_recommender/cease.py
@@ -1,0 +1,124 @@
+
+r"""
+C-EASE
+################################################
+Reference:
+    Olivier Jeunen, et al. "Closed-Form Models for Collaborative Filtering with Side-Information".
+
+Reference code:
+    https://github.com/olivierjeunen/ease-side-info-recsys-2020/
+"""
+
+
+from recbole.utils.enum_type import ModelType, FeatureType
+import numpy as np
+import scipy.sparse as sp
+import torch
+
+from recbole.utils import InputType
+from recbole.model.abstract_recommender import GeneralRecommender
+
+from sklearn.preprocessing import MultiLabelBinarizer, OneHotEncoder
+
+
+def encode_categorical_item_features(dataset, included_features):
+    item_features = dataset.get_item_feature()
+
+    mlb = MultiLabelBinarizer(sparse_output=True)
+    ohe = OneHotEncoder(sparse=True)
+
+    encoded_feats = []
+
+    for feat in included_features:
+        t = dataset.field2type[feat]
+        feat_frame = item_features[feat].numpy()
+
+        if t == FeatureType.TOKEN:
+            encoded = ohe.fit_transform(feat_frame.reshape(-1, 1))
+            encoded_feats.append(encoded)
+        elif t == FeatureType.TOKEN_SEQ:
+            encoded = mlb.fit_transform(feat_frame)
+
+            # drop first column which corresponds to the padding 0; real categories start at 1
+            # convert to csc first?
+            encoded = encoded[:, 1:]
+            encoded_feats.append(encoded)
+        else:
+            raise Warning(
+                f'CEASE/A-EASE only supports token or token_seq types. [{feat}] is of type [{t}].')
+
+    if not encoded_feats:
+        raise ValueError(
+            f'No valid token or token_seq features to include.')
+
+    return sp.hstack(encoded_feats).T.astype(np.float32)
+
+
+class CEASE(GeneralRecommender):
+    input_type = InputType.POINTWISE
+    type = ModelType.TRADITIONAL
+
+    def __init__(self, config, dataset):
+        super().__init__(config, dataset)
+
+        # need at least one param
+        self.dummy_param = torch.nn.Parameter(torch.zeros(1))
+
+        B = dataset.inter_matrix(
+            form='csr').astype(np.float32)
+
+        item_feat_weight = config['item_feat_weight']
+        reg_weight = config['reg_weight']
+        included_features = config['included_features']
+
+        T = encode_categorical_item_features(dataset, included_features)
+        T *= item_feat_weight
+
+        # just directly calculate the entire score matrix in init
+        # (can't be done incrementally)
+
+        X = sp.vstack([B, T]).tocsr()
+
+        # gram matrix
+        G = X.T @ X
+
+        # add reg to diagonal
+        G += reg_weight * sp.identity(G.shape[0])
+
+        # convert to dense because inverse will be dense
+        G = G.todense()
+
+        # invert. this takes most of the time
+        P = np.linalg.inv(G)
+        B = P / (-np.diag(P))
+        # zero out diag
+        np.fill_diagonal(B, 0.)
+
+        # instead of computing and storing the entire score matrix, just store B and compute the scores on demand
+        # more memory efficient for a larger number of users
+        # but if there's a large number of items not much one can do:
+        # still have to compute B all at once
+        # S = X @ B
+        # self.score_matrix = torch.from_numpy(S).to(self.device)
+
+        # torch doesn't support sparse tensor slicing, so will do everything with np/scipy
+        self.item_similarity = B
+        self.interaction_tag_matrix = X
+
+    def forward(self):
+        pass
+
+    def calculate_loss(self, interaction):
+        return torch.nn.Parameter(torch.zeros(1))
+
+    def predict(self, interaction):
+        user = interaction[self.USER_ID].cpu().numpy()
+        item = interaction[self.ITEM_ID].cpu().numpy()
+
+        return torch.from_numpy((self.interaction_tag_matrix[user, :].multiply(self.item_similarity[:, item].T)).sum(axis=1).getA1())
+
+    def full_sort_predict(self, interaction):
+        user = interaction[self.USER_ID].cpu().numpy()
+
+        r = self.interaction_tag_matrix[user, :] @ self.item_similarity
+        return torch.from_numpy(r.flatten())

--- a/recbole/model/general_recommender/cease.py
+++ b/recbole/model/general_recommender/cease.py
@@ -21,7 +21,7 @@ from recbole.model.abstract_recommender import GeneralRecommender
 from sklearn.preprocessing import MultiLabelBinarizer, OneHotEncoder
 
 
-def encode_categorical_item_features(dataset, included_features):
+def encode_categorical_item_features(dataset, selected_features):
     item_features = dataset.get_item_feature()
 
     mlb = MultiLabelBinarizer(sparse_output=True)
@@ -29,7 +29,7 @@ def encode_categorical_item_features(dataset, included_features):
 
     encoded_feats = []
 
-    for feat in included_features:
+    for feat in selected_features:
         t = dataset.field2type[feat]
         feat_frame = item_features[feat].numpy()
 
@@ -88,10 +88,10 @@ class CEASE(GeneralRecommender):
 
         item_feat_weight = config['item_feat_weight']
         reg_weight = config['reg_weight']
-        included_features = config['included_features']
+        selected_features = config['selected_features']
 
         tag_item_matrix = item_feat_weight * \
-            encode_categorical_item_features(dataset, included_features)
+            encode_categorical_item_features(dataset, selected_features)
 
         # just directly calculate the entire score matrix in init
         # (can't be done incrementally)

--- a/recbole/model/general_recommender/cease.py
+++ b/recbole/model/general_recommender/cease.py
@@ -90,7 +90,8 @@ class CEASE(GeneralRecommender):
         reg_weight = config['reg_weight']
         included_features = config['included_features']
 
-        tag_item_matrix = item_feat_weight * encode_categorical_item_features(dataset, included_features)
+        tag_item_matrix = item_feat_weight * \
+            encode_categorical_item_features(dataset, included_features)
 
         # just directly calculate the entire score matrix in init
         # (can't be done incrementally)

--- a/recbole/properties/model/ADDEASE.yaml
+++ b/recbole/properties/model/ADDEASE.yaml
@@ -1,0 +1,4 @@
+item_feat_proportion: 0.001
+inter_reg_weight: 350.0
+item_reg_weight: 150.0
+included_features: ['class']

--- a/recbole/properties/model/ADDEASE.yaml
+++ b/recbole/properties/model/ADDEASE.yaml
@@ -1,4 +1,4 @@
 item_feat_proportion: 0.001
 inter_reg_weight: 350.0
 item_reg_weight: 150.0
-included_features: ['class']
+selected_features: ['class']

--- a/recbole/properties/model/CEASE.yaml
+++ b/recbole/properties/model/CEASE.yaml
@@ -1,3 +1,3 @@
 item_feat_weight: 10.0
 reg_weight: 350.0
-included_features: ['class']
+selected_features: ['class']

--- a/recbole/properties/model/CEASE.yaml
+++ b/recbole/properties/model/CEASE.yaml
@@ -1,0 +1,3 @@
+item_feat_weight: 10.0
+reg_weight: 350.0
+included_features: ['class']

--- a/run_test_example.py
+++ b/run_test_example.py
@@ -150,6 +150,10 @@ test_examples = {
         'model': 'CEASE',
         'dataset': 'ml-100k',
     },
+    'Test ADDEASE': {
+        'model': 'ADDEASE',
+        'dataset': 'ml-100k',
+    },
 
     # Context-aware Recommendation
     'Test FM': {

--- a/run_test_example.py
+++ b/run_test_example.py
@@ -146,6 +146,10 @@ test_examples = {
         'model': 'MacridVAE',
         'dataset': 'ml-100k',
     },
+    'Test CEASE': {
+        'model': 'CEASE',
+        'dataset': 'ml-100k',
+    },
 
     # Context-aware Recommendation
     'Test FM': {

--- a/tests/model/test_model_auto.py
+++ b/tests/model/test_model_auto.py
@@ -181,6 +181,12 @@ class TestGeneralRecommender(unittest.TestCase):
         }
         quick_test(config_dict)
 
+    def test_ADDEASE(self):
+        config_dict = {
+            'model': 'ADDEASE',
+        }
+        quick_test(config_dict)
+
 class TestContextRecommender(unittest.TestCase):
     # todo: more complex context information should be test, such as criteo dataset
 

--- a/tests/model/test_model_auto.py
+++ b/tests/model/test_model_auto.py
@@ -175,6 +175,12 @@ class TestGeneralRecommender(unittest.TestCase):
         }
         quick_test(config_dict)
 
+    def test_CEASE(self):
+        config_dict = {
+            'model': 'CEASE',
+        }
+        quick_test(config_dict)
+
 class TestContextRecommender(unittest.TestCase):
     # todo: more complex context information should be test, such as criteo dataset
 


### PR DESCRIPTION
Both models from "Closed-Form Models for Collaborative Filtering with Side-Information" by Olivier Jeunen, et al. https://dl.acm.org/doi/abs/10.1145/3383313.3418480

These are variations of EASE which incorporate item token and token_seq features. Small accuracy improvements over EASE (indeed, EASE is a special case of ADD-EASE with `item_feat_proportion = 0.0`). The paper claims large improvements for cold-start items, but unfortunately there is no way to check that in RecBole https://github.com/RUCAIBox/RecBole/issues/671

The model in the paper allows feature-specific importance weighting, but didn't test that variant (probably because there is no obvious way in general to assign importance). So, in the case of C-EASE I just implemented a single parameter controlling the importance of item features (as is tested in the paper).