### PR TITLE
update fetch interaction matrix of sequential dataset

### DIFF
--- a/recbole/data/dataset/sequential_dataset.py
+++ b/recbole/data/dataset/sequential_dataset.py
@@ -106,6 +106,26 @@ class SequentialDataset(Dataset):
             next_ds.append(ds)
         return next_ds
 
+    def inter_matrix(self, form='coo', value_field=None):
+        """Get sparse matrix that describe interactions between user_id and item_id.
+        Sparse matrix has shape (user_num, item_num).
+        For a row of <src, tgt>, ``matrix[src, tgt] = 1`` if ``value_field`` is ``None``,
+        else ``matrix[src, tgt] = self.inter_feat[src, tgt]``.
+        Args:
+            form (str, optional): Sparse matrix format. Defaults to ``coo``.
+            value_field (str, optional): Data of sparse matrix, which should exist in ``df_feat``.
+                Defaults to ``None``.
+        Returns:
+            scipy.sparse: Sparse matrix in form ``coo`` or ``csr``.
+        """
+        if not self.uid_field or not self.iid_field:
+            raise ValueError('dataset does not exist uid/iid, thus can not converted to sparse matrix.')
+
+        self.logger.warning('Load interaction matrix may lead to label leakage from testing phase, this implementation '
+                            'only provides the interactions corresponding to specific phase')
+        local_inter_feat = self.inter_feat[self.uid_list]
+        return self._create_sparse_matrix(local_inter_feat, self.uid_field, self.iid_field, form, value_field)
+
     def build(self, eval_setting):
         ordering_args = eval_setting.ordering_args
         if ordering_args['strategy'] == 'shuffle':


### PR DESCRIPTION
I assume [this issue](https://github.com/RUCAIBox/RecBole/issues/620) been done but it seems not yet. Sorry for the late response.

Just a quick confirmation that I found the `self.uid_list` for individual data_loader are different, and it covers the indices number for a specific phase, so I directly apply  `local_inter_feat = self.inter_feat[self.uid_list]` to get the interaction matrix for the specific phase, correct me if I am wrong.