### PR TITLE
FEA: shuffle scores randomly & fix typos

### DIFF
--- a/recbole/evaluator/evaluators.py
+++ b/recbole/evaluator/evaluators.py
@@ -51,7 +51,6 @@ class TopKEvaluator(GroupedEvaluator):
         self._check_args()
 
 
-    @profile
     def collect(self, interaction, scores_tensor):
         """collect the topk intermediate result of one batch, this function mainly
         implements padding and TopK finding. It is called at the end of each batch

--- a/recbole/evaluator/evaluators.py
+++ b/recbole/evaluator/evaluators.py
@@ -50,7 +50,6 @@ class TopKEvaluator(GroupedEvaluator):
         self.topk = config['topk']
         self._check_args()
 
-
     def collect(self, interaction, scores_tensor):
         """collect the topk intermediate result of one batch, this function mainly
         implements padding and TopK finding. It is called at the end of each batch
@@ -67,6 +66,7 @@ class TopKEvaluator(GroupedEvaluator):
 
         scores_matrix = self.get_score_matrix(scores_tensor, user_len_list)
         random_index = torch.randperm(scores_matrix.shape[1], device=scores_matrix.device)
+        import pdb; pdb.set_trace()
         shuffle_scores = scores_matrix.index_select(1, random_index)
 
         # get topk
@@ -238,7 +238,7 @@ class RankEvaluator(GroupedEvaluator):
             eval_data (Dataset): the class of test data
 
         Returns:
-            dict: such as ``{'GAUC:0.9286}``
+            dict: such as ``{'GAUC': 0.9286}``
 
         """
         pos_len_list = eval_data.get_pos_len_list()
@@ -277,8 +277,6 @@ class RankEvaluator(GroupedEvaluator):
         msg = 'The Rank Evaluator Info:\n' + \
               '\tMetrics:[' + \
               ', '.join([rank_metrics[metric.lower()] for metric in self.metrics]) + \
-              '], TopK:[' + \
-              ', '.join(map(str, self.topk)) + \
               ']'
         return msg
 

--- a/recbole/evaluator/evaluators.py
+++ b/recbole/evaluator/evaluators.py
@@ -66,7 +66,6 @@ class TopKEvaluator(GroupedEvaluator):
 
         scores_matrix = self.get_score_matrix(scores_tensor, user_len_list)
         random_index = torch.randperm(scores_matrix.shape[1], device=scores_matrix.device)
-        import pdb; pdb.set_trace()
         shuffle_scores = scores_matrix.index_select(1, random_index)
 
         # get topk

--- a/recbole/evaluator/metrics.py
+++ b/recbole/evaluator/metrics.py
@@ -120,13 +120,13 @@ def ndcg_(pos_index, pos_len):
             \mathrm {DCG@K}=\sum_{i=1}^{K} \frac{2^{rel_i}-1}{\log_{2}{(i+1)}}\\
             \mathrm {IDCG@K}=\sum_{i=1}^{K}\frac{1}{\log_{2}{(i+1)}}\\
             \mathrm {NDCG_u@K}=\frac{DCG_u@K}{IDCG_u@K}\\
-            \mathrm {NDCG@K}=\frac{\sum \nolimits_{u \in u^{te}NDCG_u@K}}{|u^{te}|}
+            \mathrm {NDCG@K}=\frac{\sum \nolimits_{u \in U^{te}NDCG_u@K}}{|U^{te}|}
         \end{gather}
 
     :math:`K` stands for recommending :math:`K` items.
     And the :math:`rel_i` is the relevance of the item in position :math:`i` in the recommendation list.
-    :math:`2^{rel_i}` equals to 1 if the item hits otherwise 0.
-    :math:`U^{te}` is for all users in the test set.
+    :math:`{rel_i}` equals to 1 if the item is ground truth otherwise 0.
+    :math:`U^{te}` stands for all users in the test set.
 
     """
     len_rank = np.full_like(pos_len, pos_index.shape[1])


### PR DESCRIPTION
1. Shuffling scores randomly before performing top-k ranking.
2. Fix typos in docs for NDCG annd example of `average rank`.