### PR TITLE
Bugfix: add RaCT to __init__.py

### DIFF
--- a/recbole/model/general_recommender/__init__.py
+++ b/recbole/model/general_recommender/__init__.py
@@ -19,6 +19,7 @@ from recbole.model.general_recommender.neumf import NeuMF
 from recbole.model.general_recommender.ngcf import NGCF
 from recbole.model.general_recommender.nncf import NNCF
 from recbole.model.general_recommender.pop import Pop
+from recbole.model.general_recommender.ract import RaCT
 from recbole.model.general_recommender.recvae import RecVAE
 from recbole.model.general_recommender.slimelastic import SLIMElastic
 from recbole.model.general_recommender.spectralcf import SpectralCF


### PR DESCRIPTION
I added your RaCT model to the init file so that it is importable like the other models:

```python
from recbole.model.general_recommender import RaCT
````

It was not yet included, but the model works so I guess I can call this a bugfix 😄 