### PR TITLE
Documentation Improvement: Added examples for specific trainers

### DIFF
--- a/docs/source/user_guide/model/context/lightgbm.rst
+++ b/docs/source/user_guide/model/context/lightgbm.rst
@@ -41,6 +41,63 @@ And then:
 .. code:: bash
 
    python run.py
+
+**Elaborated example**
+
+Note: a custom lightgbmTrainer should be imported in order for the code to work!
+
+.. code:: python
+   from logging import getLogger
+   from recbole.config import Config
+   from recbole.data import create_dataset, data_preparation
+   from recbole.model.exlib_recommender import lightgbm
+   from recbole.trainer import lightgbmTrainer
+   from recbole.utils import init_seed, init_logger
+
+   if __name__ == '__main__':
+       config = Config(model='lightgbm', dataset='X', config_file_list=['X.yaml'])
+       dataset = create_dataset(config)
+
+       # init random seed
+       init_seed(config['seed'], config['reproducibility'])
+
+       # logger initialization
+       init_logger(config)
+       logger = getLogger()
+
+       # write config info into log
+       logger.info(config)
+
+       # dataset creating and filtering
+       dataset = create_dataset(config)
+       logger.info(dataset)
+
+       # dataset splitting
+       train_data, valid_data, test_data = data_preparation(config, dataset)
+
+       config['lgb_params'] = {
+           'boosting': 'gbdt',
+           'objective': 'binary',
+           'metric': ['auc', 'binary_logloss']
+       }
+
+       config['lgb_num_boost_round'] = 100
+
+       # model loading and initialization
+       model = lightgbm(config, train_data).to(config['device'])
+       logger.info(model)
+
+       # trainer loading and initialization
+       trainer = lightgbmTrainer(config, model)
+
+       # model training
+       best_valid_score, best_valid_result = trainer.fit(
+           train_data, valid_data, show_progress=True)
+
+       # model evaluation
+       test_result = trainer.evaluate(test_data)
+       print(test_result)
+
  
 
 If you want to change parameters, dataset or evaluation settings, take a look at

--- a/docs/source/user_guide/model/context/lightgbm.rst
+++ b/docs/source/user_guide/model/context/lightgbm.rst
@@ -47,6 +47,7 @@ And then:
 Note: a custom lightgbmTrainer should be imported in order for the code to work!
 
 .. code:: python
+
    from logging import getLogger
    from recbole.config import Config
    from recbole.data import create_dataset, data_preparation

--- a/docs/source/user_guide/model/general/recvae.rst
+++ b/docs/source/user_guide/model/general/recvae.rst
@@ -53,6 +53,33 @@ And then:
 
 **Note**: Because this model is a non-sampling model, so you must set ``training_neg_sample=0`` when you run this model. 
 
+**Example with RecVAE Trainer**
+
+In order to use the RecVAE model, a specific RecVAE Trainer should be imported
+
+.. code:: python
+	from logging import getLogger
+	from recbole.config import Config
+	from recbole.data import create_dataset, data_preparation
+	from recbole.model.general_recommender import RecVAE
+	from recbole.trainer import RecVAETrainer
+	from recbole.utils import init_seed, init_logger
+
+	if __name__ == '__main__':
+	    config = Config(model='RecVAE', dataset='x', config_file_list=['x.yaml'])
+	    dataset = create_dataset(config)
+	    init_seed(config['seed'], config['reproducibility'])
+	    init_logger(config)
+	    logger = getLogger()
+	    dataset = create_dataset(config)
+	    train_data, valid_data, test_data = data_preparation(config, dataset)
+	    model = RecVAE(config, train_data).to(config['device'])
+	    logger.info(model)
+
+	    # Specific trainer
+	    trainer = RecVAETrainer(config, model)
+
+
 Tuning Hyper Parameters
 -------------------------
 

--- a/docs/source/user_guide/model/general/recvae.rst
+++ b/docs/source/user_guide/model/general/recvae.rst
@@ -58,6 +58,7 @@ And then:
 In order to use the RecVAE model, a specific RecVAE Trainer should be imported
 
 .. code:: python
+
 	from logging import getLogger
 	from recbole.config import Config
 	from recbole.data import create_dataset, data_preparation


### PR DESCRIPTION
Hello guys, when working with your library I stumbled upon the following error when I tried to run RecVae with the **basic Trainer**:

```python
 File ".../recbole/trainer/trainer.py", line 160, in _train_epoch
    losses = loss_func(interaction)
TypeError: calculate_loss() missing 1 required positional argument: 'encoder_flag'
```
 I went through your codebase to check whether I made a mistake and I saw that you had implemented custom trainers for a couple of models! With the custom RecVAETrainer this error was quickly resolved. Since this was missing in the docs I updated both the RecVAE and LightGBM model documentation and added a more elaborated example that should clear things up for future devs 😄 Thanks for the great library, I am a huge fan

