### PR TITLE
It's nice to be able to run the CI manually and on push 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,9 +4,7 @@ name: RecBole tests
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,8 +1,15 @@
 name: RecBole tests
 
+# Controls when the action will run. 
 on:
-- pull_request
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
I think it's nice to be able to run the test manually and on push by adding the `on event` in the github action. 