### PR TITLE
Cleared the error message

### DIFF
--- a/recbole/data/dataset/dataset.py
+++ b/recbole/data/dataset/dataset.py
@@ -1051,11 +1051,11 @@ class Dataset(object):
             if tokens in self.field2token_id[field]:
                 return self.field2token_id[field][tokens]
             else:
-                raise ValueError('token [{}] is not existed')
+                raise ValueError(f'token [{token}] is not existed in {field}')
         elif isinstance(tokens, (list, np.ndarray)):
             return np.array([self.token2id(field, token) for token in tokens])
         else:
-            raise TypeError('The type of tokens [{}] is not supported')
+            raise TypeError(f'The type of tokens [{token}] is not supported')
 
     @dlapi.set()
     def id2token(self, field, ids):


### PR DESCRIPTION
When error, the message is not clear. 

I added a message to show which token is not found in which field. This can help users to identify their errors quickly.