### PR TITLE
fix save dir of dataset bugs

### DIFF
--- a/recbole/data/dataset/dataset.py
+++ b/recbole/data/dataset/dataset.py
@@ -3,9 +3,9 @@
 # @Email  : houyupeng@ruc.edu.cn
 
 # UPDATE:
-# @Time   : 2021/7/14 2021/7/1, 2020/11/10
-# @Author : Yupeng Hou, Xingyu Pan, Yushuo Chen
-# @Email  : houyupeng@ruc.edu.cn, xy_pan@foxmail.com, chenyushuo@ruc.edu.cn
+# @Time   : 2021/12/18 2021/7/14 2021/7/1, 2020/11/10
+# @Author : Yupeng Hou, Xingyu Pan, Yushuo Chen, Juyong Jiang
+# @Email  : houyupeng@ruc.edu.cn, xy_pan@foxmail.com, chenyushuo@ruc.edu.cn, csjuyongjiang@gmail.com
 
 """
 recbole.data.dataset
@@ -1508,7 +1508,10 @@ class Dataset(object):
     def save(self):
         """Saving this :class:`Dataset` object to :attr:`config['checkpoint_dir']`.
         """
-        file = os.path.join(self.config['checkpoint_dir'], f'{self.config["dataset"]}-dataset.pth')
+        save_dir = self.config['checkpoint_dir']
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+        file = os.path.join(save_dir, f'{self.config["dataset"]}-dataset.pth')
         self.logger.info(set_color('Saving filtered dataset into ', 'pink') + f'[{file}]')
         with open(file, 'wb') as f:
             pickle.dump(self, f)

--- a/recbole/data/dataset/dataset.py
+++ b/recbole/data/dataset/dataset.py
@@ -1509,8 +1509,7 @@ class Dataset(object):
         """Saving this :class:`Dataset` object to :attr:`config['checkpoint_dir']`.
         """
         save_dir = self.config['checkpoint_dir']
-        if not os.path.exists(save_dir):
-            os.makedirs(save_dir)
+        ensure_dir(self.config['checkpoint_dir'])
         file = os.path.join(save_dir, f'{self.config["dataset"]}-dataset.pth')
         self.logger.info(set_color('Saving filtered dataset into ', 'pink') + f'[{file}]')
         with open(file, 'wb') as f:

--- a/recbole/properties/overall.yaml
+++ b/recbole/properties/overall.yaml
@@ -7,8 +7,8 @@ reproducibility: True
 data_path: 'dataset/'
 checkpoint_dir: 'saved'
 show_progress: True
-save_dataset: True
-save_dataloaders: True
+save_dataset: False
+save_dataloaders: False
 
 # training settings
 epochs: 300

--- a/recbole/properties/overall.yaml
+++ b/recbole/properties/overall.yaml
@@ -7,8 +7,8 @@ reproducibility: True
 data_path: 'dataset/'
 checkpoint_dir: 'saved'
 show_progress: True
-save_dataset: False
-save_dataloaders: False
+save_dataset: True
+save_dataloaders: True
 
 # training settings
 epochs: 300


### PR DESCRIPTION
To save filtered dataset and split dataloaders, I set parameter `save_dataset=True ` and parameter `save_dataloaders=True`, as suggested in [https://recbole.io/docs/user_guide/config/environment_settings.html](https://recbole.io/docs/user_guide/config/environment_settings.html) and [https://recbole.io/docs/user_guide/usage/save_and_load_data_and_model.html](https://recbole.io/docs/user_guide/usage/save_and_load_data_and_model.html). 

But it occurs some bugs which show that the directory of `self.config['checkpoint_dir']` does not exist. So I check the corresponding source code of `save` function to add a few lines of code to automatically make save dir if it does not exist. 

![0dc549cf75717892f3647fca6e940a6](https://user-images.githubusercontent.com/50765248/146634082-b4e82f66-d2cc-4600-86f5-fe9632ab2674.png)
