### PR TITLE
Add Weights and Biases Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ saved/
 *.lprof
 *.egg-info/
 docs/build/
+wandb/*

--- a/recbole/properties/overall.yaml
+++ b/recbole/properties/overall.yaml
@@ -9,6 +9,7 @@ checkpoint_dir: 'saved'
 show_progress: True
 save_dataset: False
 save_dataloaders: False
+log_wandb: True
 
 # training settings
 epochs: 300

--- a/recbole/properties/overall.yaml
+++ b/recbole/properties/overall.yaml
@@ -10,6 +10,7 @@ show_progress: True
 save_dataset: False
 save_dataloaders: False
 log_wandb: False
+wandb_project: 'recbole'
 
 # training settings
 epochs: 300

--- a/recbole/properties/overall.yaml
+++ b/recbole/properties/overall.yaml
@@ -9,7 +9,7 @@ checkpoint_dir: 'saved'
 show_progress: True
 save_dataset: False
 save_dataloaders: False
-log_wandb: True
+log_wandb: False
 
 # training settings
 epochs: 300

--- a/recbole/trainer/trainer.py
+++ b/recbole/trainer/trainer.py
@@ -322,6 +322,7 @@ class Trainer(AbstractTrainer):
             if verbose:
                 self.logger.info(train_loss_output)
             self._add_train_loss_to_tensorboard(epoch_idx, train_loss)
+            self.wandblogger.log_metrics({'epoch': epoch_idx, 'train_loss': train_loss}, head='train')
 
             # eval
             if self.eval_step <= 0 or not valid_data:
@@ -350,6 +351,7 @@ class Trainer(AbstractTrainer):
                     self.logger.info(valid_score_output)
                     self.logger.info(valid_result_output)
                 self.tensorboard.add_scalar('Vaild_score', valid_score, epoch_idx)
+                self.wandblogger.log_metrics(valid_result, head='valid')
 
                 if update_flag:
                     if saved:
@@ -465,7 +467,8 @@ class Trainer(AbstractTrainer):
         self.eval_collector.model_collect(self.model)
         struct = self.eval_collector.get_data_struct()
         result = self.evaluator.evaluate(struct)
-
+        self.wandblogger.log_metrics(result, head='eval')
+        
         return result
 
     def _spilt_predict(self, interaction, batch_size):

--- a/recbole/trainer/trainer.py
+++ b/recbole/trainer/trainer.py
@@ -31,7 +31,7 @@ from recbole.data.interaction import Interaction
 from recbole.data.dataloader import FullSortEvalDataLoader
 from recbole.evaluator import Evaluator, Collector
 from recbole.utils import ensure_dir, get_local_time, early_stopping, calculate_valid_score, dict2str, \
-    EvaluatorType, KGDataLoaderState, get_tensorboard, set_color, get_gpu_usage
+    EvaluatorType, KGDataLoaderState, get_tensorboard, set_color, get_gpu_usage, WandbLogger
 
 
 class AbstractTrainer(object):
@@ -78,6 +78,7 @@ class Trainer(AbstractTrainer):
 
         self.logger = getLogger()
         self.tensorboard = get_tensorboard(self.logger)
+        self.wandblogger = WandbLogger(config)
         self.learner = config['learner']
         self.learning_rate = config['learning_rate']
         self.epochs = config['epochs']

--- a/recbole/utils/__init__.py
+++ b/recbole/utils/__init__.py
@@ -3,10 +3,11 @@ from recbole.utils.utils import get_local_time, ensure_dir, get_model, get_train
     early_stopping, calculate_valid_score, dict2str, init_seed, get_tensorboard, get_gpu_usage
 from recbole.utils.enum_type import *
 from recbole.utils.argument_list import *
+from recbole.utils.wandblogger import WandbLogger
 
 __all__ = [
     'init_logger', 'get_local_time', 'ensure_dir', 'get_model', 'get_trainer', 'early_stopping',
     'calculate_valid_score', 'dict2str', 'Enum', 'ModelType', 'KGDataLoaderState', 'EvaluatorType', 'InputType',
     'FeatureType', 'FeatureSource', 'init_seed', 'general_arguments', 'training_arguments', 'evaluation_arguments',
-    'dataset_arguments', 'get_tensorboard', 'set_color', 'get_gpu_usage'
+    'dataset_arguments', 'get_tensorboard', 'set_color', 'get_gpu_usage', 'WandbLogger'
 ]

--- a/recbole/utils/argument_list.py
+++ b/recbole/utils/argument_list.py
@@ -15,6 +15,7 @@ general_arguments = [
     'config_file',
     'save_dataset',
     'save_dataloaders',
+    'log_wandb',
 ]
 
 training_arguments = [

--- a/recbole/utils/wandblogger.py
+++ b/recbole/utils/wandblogger.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# @Time   : 2022/8/2
+# @Author : Ayush Thakur
+# @Email  : ayusht@wandb.com
+
+r"""
+recbole.utils.wandblogger
+################################
+"""
+
+class WandbLogger(object):
+    """WandbLogger to log metrics to Weights and Biases.
+
+    """
+    def __init__(self, config):
+        """
+        Args:
+            config (dict): A dictionary of parameters used by RecBole.
+        """
+        self.config = config
+        self.log_wandb = config.log_wandb
+        self.setup()
+        
+    def setup(self):
+        if self.log_wandb:
+            try:
+                import wandb
+                self._wandb = wandb
+            except ImportError:
+                raise ImportError(
+                    "To use the Weights and Biases Logger please install wandb."
+                    "Run `pip install wandb` to install it."
+                )
+
+            # Initialize a W&B run
+            if self._wandb.run is None:
+                self._wandb.init(
+                    project='recbole-test',
+                    config=self.config
+                )
+
+
+    def log_metrics(self):
+        pass

--- a/recbole/utils/wandblogger.py
+++ b/recbole/utils/wandblogger.py
@@ -39,6 +39,18 @@ class WandbLogger(object):
                     config=self.config
                 )
 
+    def log_metrics(self, metrics, head='train'):
+        if self.log_wandb:
+            if head:
+                metrics = self.add_head_to_metrics(metrics, head)
+                self._wandb.log(metrics)
+            else:
+                self._wandb.log(metrics)
 
-    def log_metrics(self):
-        pass
+    def add_head_to_metrics(self, metrics, head):
+        head_metrics = dict()
+        for k, v in metrics.items():
+            head_metrics[f'{head}/{k}'] = v
+
+        return head_metrics
+        


### PR DESCRIPTION
This PR adds support for [Weights and Biases](https://wandb.ai/site) experiment tracking (metric logging).

# Usage

I have tested the implementation using the quick start provided with this repo. We can start logging metrics to W&B by passing `--log_wandb=True` as command line argument, or use config dict. One can also turn `log_wandb: True` in the `overall.yaml` file or provide it as external config file. 

```
python run_recbole.py --epochs=10 --log_wandb=True
```

# Result (Feature Addition)

* Able to easily share the experiments. Here's an [example W&B run](https://wandb.ai/ayush-thakur/recbole/runs/es3wyf9j?workspace=user-ayut) that shows train and valid metrics from generated by running the quick start. 
* Ability to check out the exact configuration used to train the model. Configs can thus be easily compared across experiments. 
* Keep track of evaluation metrics.
* Know the exact command used to train the model. 

https://user-images.githubusercontent.com/31141479/153084427-176ab35b-a440-4f39-bf2a-c0981df38c89.mov

# Potential Addition

I hope you find it useful. In addition to the feature I have implemented I can potentially add the follow:
- [ ] Log the model checkpoint as [W&B Artifacts](https://docs.wandb.ai/guides/artifacts) to version control. This can be done with few lines of code. 
- [ ] Log model prediction as [W&B Tables](https://docs.wandb.ai/guides/data-vis). This will allow to evaluate model prediction interactively and query results on W&B dashboard. This will be a bigger implementation project and might require some feedback. 

This is an amazing repository which I am going to use for the recently launched [H&M Personalized Fashion Recommendations](https://www.kaggle.com/c/h-and-m-personalized-fashion-recommendations) Kaggle competiiton. 