### PR TITLE
FIX: fix UserWarning in get_norm_adj_mat and accelerate csr2tensor

### DIFF
--- a/recbole/model/general_recommender/lightgcn.py
+++ b/recbole/model/general_recommender/lightgcn.py
@@ -100,7 +100,7 @@ class LightGCN(GeneralRecommender):
         L = sp.coo_matrix(L)
         row = L.row
         col = L.col
-        i = torch.LongTensor([row, col])
+        i = torch.LongTensor(np.array([row, col]))
         data = torch.FloatTensor(L.data)
         SparseL = torch.sparse.FloatTensor(i, data, torch.Size(L.shape))
         return SparseL

--- a/recbole/model/general_recommender/ncl.py
+++ b/recbole/model/general_recommender/ncl.py
@@ -121,7 +121,7 @@ class NCL(GeneralRecommender):
         L = sp.coo_matrix(L)
         row = L.row
         col = L.col
-        i = torch.LongTensor([row, col])
+        i = torch.LongTensor(np.array([row, col]))
         data = torch.FloatTensor(L.data)
         SparseL = torch.sparse.FloatTensor(i, data, torch.Size(L.shape))
         return SparseL

--- a/recbole/model/general_recommender/ngcf.py
+++ b/recbole/model/general_recommender/ngcf.py
@@ -103,7 +103,7 @@ class NGCF(GeneralRecommender):
         L = sp.coo_matrix(L)
         row = L.row
         col = L.col
-        i = torch.LongTensor([row, col])
+        i = torch.LongTensor(np.array([row, col]))
         data = torch.FloatTensor(L.data)
         SparseL = torch.sparse.FloatTensor(i, data, torch.Size(L.shape))
         return SparseL

--- a/recbole/model/general_recommender/sgl.py
+++ b/recbole/model/general_recommender/sgl.py
@@ -156,7 +156,7 @@ class SGL(GeneralRecommender):
         """
         matrix = matrix.tocoo()
         x = torch.sparse.FloatTensor(
-            torch.LongTensor([matrix.row.tolist(), matrix.col.tolist()]),
+            torch.LongTensor(np.array([matrix.row, matrix.col])),
             torch.FloatTensor(matrix.data.astype(np.float32)), matrix.shape
         ).to(self.device)
         return x


### PR DESCRIPTION
When running LightGCN, NGCF and NCL, there will be a UserWarning as follows:
```
UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor.
```


The reason is that in `get_norm_adj_mat`, the type of `L.row` and `L.col` is `numpy.ndarray`, so `i =torch.LongTensor(np.array([row, col]))` creates a tensor from a list of numpy.ndarrays.

https://github.com/RUCAIBox/RecBole/blob/4f761699454fd5d8873607173d2514d38ac24031/recbole/model/general_recommender/lightgcn.py#L99-L103


In SGL, `numpy.ndarray` is converted to `list` by `.tolist()` to avoid the warning.
https://github.com/RUCAIBox/RecBole/blob/4f761699454fd5d8873607173d2514d38ac24031/recbole/model/general_recommender/sgl.py#L158-L161


I test the running time of three methods on ml-1m, and _converting the list to a single `numpy.ndarray` with `numpy.array()`before converting to a tensor_ is the quickest.

- 含 numpy 的 list 直接转 LongTensor: 

```python
stime = time.time()
row = L.row
col = L.col
i = torch.LongTensor([row, col])
etime = time.time()
print(f'用时: {etime-stime}s')
0.3401050567626953s
```

- 先将 list 的 numpy 转为 list，再转 LongTensor: 

```python
stime = time.time()
row = L.row.tolist()
col = L.col.tolist()
i = torch.LongTensor([row, col])
etime = time.time()
print(f'用时: {etime-stime}s')
0.14787578582763672s
```

- 含 numpy 的 list 先转 numpy 再转 LongTensor: 

```python
stime = time.time()
row = L.row
col = L.col
i = torch.LongTensor(np.array([row, col]))
etime = time.time()
print(f'用时: {etime-stime}s')
0.0045320987701416016s
```