### PR TITLE
Docs: Insert eval_collector.data_collect when evaluate from checkpoint (calculate ItemCoverage)

### DIFF
--- a/docs/source/user_guide/usage/use_modules.rst
+++ b/docs/source/user_guide/usage/use_modules.rst
@@ -196,6 +196,9 @@ In this example, we present how to test a model based on the previous saved para
         # trainer loading and initialization
         trainer = get_trainer(config['MODEL_TYPE'], config['model'])(config, model)
 
+        # When calculate ItemCoverage metrics, we need to run this code for set item_nums in eval_collector.
+        trainer.eval_collector.data_collect(train_data)
+
         # model evaluation
         checkpoint_file = 'checkpoint.pth'
         test_result = trainer.evaluate(test_data, model_file=checkpoint_file)


### PR DESCRIPTION
Hi 
When I added ItemCoverage to my metrics config and ran trainer.evaluate from checkpoint, I got the following error.

```
Traceback (most recent call last):
  File "src/tools/evaluate_only.py", line 156, in <module>
    main()
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "src/tools/evaluate_only.py", line 147, in main
    test_result = trainer.evaluate(test_data, model_file=checkpoint)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/recbole/trainer/trainer.py", line 481, in evaluate
    result = self.evaluator.evaluate(struct)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/recbole/evaluator/evaluator.py", line 40, in evaluate
    metric_val = self.metric_class[metric].calculate_metric(dataobject)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/recbole/evaluator/metrics.py", line 462, in calculate_metric
    item_matrix, num_items = self.used_info(dataobject)
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/recbole/evaluator/metrics.py", line 458, in used_info
    num_items = dataobject.get('data.num_items')
  File "/home/yusuke-fukasawa/.cache/pypoetry/virtualenvs/teller-novel-recbole-nYDNORo--py3.8/lib/python3.8/site-packages/recbole/evaluator/collector.py", line 39, in get
    raise IndexError("Can not load the data without registration !")
IndexError: Can not load the data without registration !
```

After reviewing the code, I thought that the code in the documentation would not set `data.item_nums` to eval_collector, resulting in the above error.
I actually inserted the code `trainer.eval_collector.data_collect(train_data)` and ran it again and it worked. 

So, in this PR, I proposed to insert this code in `we present how to test a model based on the previous saved parameters.` (`use_modules.rst`).