### PR TITLE
Change to cuda behavior for autoencoder models

### DIFF
--- a/recbole/model/abstract_recommender.py
+++ b/recbole/model/abstract_recommender.py
@@ -110,10 +110,13 @@ class GeneralRecommender(AbstractRecommender):
 
 
 class AutoEncoderMixin(object):
+    """This is a common part of auto-encoders. All the auto-encoder models should inherit this class,
+    including CDAE, MacridVAE, MultiDAE, MultiVAE, RaCT and RecVAE.
+    The base AutoEncoderMixin class provides basic dataset information and rating matrix function.
+    """
+    
     def build_histroy_items(self, dataset):
         self.history_item_id, self.history_item_value, _ = dataset.history_item_matrix()
-        self.history_item_id = self.history_item_id
-        self.history_item_value = self.history_item_value
 
     def get_rating_matrix(self, user):
         r"""Get a batch of user's feature with the user's id and history interaction matrix.

--- a/recbole/model/abstract_recommender.py
+++ b/recbole/model/abstract_recommender.py
@@ -109,6 +109,37 @@ class GeneralRecommender(AbstractRecommender):
         self.device = config["device"]
 
 
+class AutoEncoderMixin(object):
+    def build_histroy_items(self, dataset):
+        self.history_item_id, self.history_item_value, _ = dataset.history_item_matrix()
+        self.history_item_id = self.history_item_id
+        self.history_item_value = self.history_item_value
+
+    def get_rating_matrix(self, user):
+        r"""Get a batch of user's feature with the user's id and history interaction matrix.
+
+        Args:
+            user (torch.LongTensor): The input tensor that contains user's id, shape: [batch_size, ]
+
+        Returns:
+            torch.FloatTensor: The user's feature of a batch of user, shape: [batch_size, n_items]
+        """
+        # Following lines construct tensor of shape [B,n_items] using the tensor of shape [B,H]
+        col_indices = self.history_item_id[user].flatten()
+        row_indices = (
+            torch.arange(user.shape[0])
+            .repeat_interleave(self.history_item_id.shape[1], dim=0)
+        )
+        rating_matrix = (
+            torch.zeros(1).repeat(user.shape[0], self.n_items)
+        )
+        rating_matrix.index_put_(
+            (row_indices, col_indices), self.history_item_value[user].flatten()
+        )
+        rating_matrix = rating_matrix.to(self.device)
+        return rating_matrix
+
+
 class SequentialRecommender(AbstractRecommender):
     """
     This is a abstract sequential recommender. All the sequential model should implement This class.

--- a/recbole/model/general_recommender/cdae.py
+++ b/recbole/model/general_recommender/cdae.py
@@ -8,7 +8,7 @@ CDAE
 ################################################
 Reference:
     Yao Wu et al., Collaborative denoising auto-encoders for top-n recommender systems. In WSDM 2016.
-   
+
 Reference code:
     https://github.com/jasonyaw/CDAE
 """
@@ -16,12 +16,12 @@ Reference code:
 import torch
 import torch.nn as nn
 
-from recbole.model.abstract_recommender import GeneralRecommender
+from recbole.model.abstract_recommender import AutoEncoderMixin, GeneralRecommender
 from recbole.model.init import xavier_normal_initialization
 from recbole.utils import InputType
 
 
-class CDAE(GeneralRecommender):
+class CDAE(GeneralRecommender, AutoEncoderMixin):
     r"""Collaborative Denoising Auto-Encoder (CDAE) is a recommendation model
     for top-N recommendation that utilizes the idea of Denoising Auto-Encoders.
     We implement the the CDAE model with only user dataloader.
@@ -39,9 +39,7 @@ class CDAE(GeneralRecommender):
         self.embedding_size = config["embedding_size"]
         self.corruption_ratio = config["corruption_ratio"]
 
-        self.history_item_id, self.history_item_value, _ = dataset.history_item_matrix()
-        self.history_item_id = self.history_item_id.to(self.device)
-        self.history_item_value = self.history_item_value.to(self.device)
+        self.build_histroy_items(dataset)
 
         if self.hid_activation == "sigmoid":
             self.h_act = nn.Sigmoid()
@@ -76,30 +74,6 @@ class CDAE(GeneralRecommender):
         h = self.h_act(h)
         out = self.out_layer(h)
         return out
-
-    def get_rating_matrix(self, user):
-        r"""Get a batch of user's feature with the user's id and history interaction matrix.
-
-        Args:
-            user (torch.LongTensor): The input tensor that contains user's id, shape: [batch_size, ]
-
-        Returns:
-            torch.FloatTensor: The user's feature of a batch of user, shape: [batch_size, n_items]
-        """
-        # Following lines construct tensor of shape [B,n_items] using the tensor of shape [B,H]
-        col_indices = self.history_item_id[user].flatten()
-        row_indices = (
-            torch.arange(user.shape[0])
-            .to(self.device)
-            .repeat_interleave(self.history_item_id.shape[1], dim=0)
-        )
-        rating_matrix = (
-            torch.zeros(1).to(self.device).repeat(user.shape[0], self.n_items)
-        )
-        rating_matrix.index_put_(
-            (row_indices, col_indices), self.history_item_value[user].flatten()
-        )
-        return rating_matrix
 
     def calculate_loss(self, interaction):
         x_users = interaction[self.USER_ID]

--- a/recbole/model/general_recommender/macridvae.py
+++ b/recbole/model/general_recommender/macridvae.py
@@ -22,13 +22,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from recbole.model.abstract_recommender import GeneralRecommender
+from recbole.model.abstract_recommender import AutoEncoderMixin, GeneralRecommender
 from recbole.model.init import xavier_normal_initialization
 from recbole.model.loss import EmbLoss
 from recbole.utils import InputType
 
 
-class MacridVAE(GeneralRecommender):
+class MacridVAE(GeneralRecommender, AutoEncoderMixin):
     r"""MacridVAE is an item-based collaborative filtering model that learns disentangled representations from user
     behavior and simultaneously ranks all items for each user.
 
@@ -51,10 +51,7 @@ class MacridVAE(GeneralRecommender):
         self.std = config["std"]
 
         self.update = 0
-
-        self.history_item_id, self.history_item_value, _ = dataset.history_item_matrix()
-        self.history_item_id = self.history_item_id.to(self.device)
-        self.history_item_value = self.history_item_value.to(self.device)
+        self.build_histroy_items(dataset)
         self.encode_layer_dims = (
             [self.n_items] + self.layers + [self.embedding_size * 2]
         )
@@ -67,30 +64,6 @@ class MacridVAE(GeneralRecommender):
         self.l2_loss = EmbLoss()
         # parameters initialization
         self.apply(xavier_normal_initialization)
-
-    def get_rating_matrix(self, user):
-        r"""Get a batch of user's feature with the user's id and history interaction matrix.
-
-        Args:
-            user (torch.LongTensor): The input tensor that contains user's id, shape: [batch_size, ]
-
-        Returns:
-            torch.FloatTensor: The user's feature of a batch of user, shape: [batch_size, n_items]
-        """
-        # Following lines construct tensor of shape [B,n_items] using the tensor of shape [B,H]
-        col_indices = self.history_item_id[user].flatten()
-        row_indices = (
-            torch.arange(user.shape[0])
-            .to(self.device)
-            .repeat_interleave(self.history_item_id.shape[1], dim=0)
-        )
-        rating_matrix = (
-            torch.zeros(1).to(self.device).repeat(user.shape[0], self.n_items)
-        )
-        rating_matrix.index_put_(
-            (row_indices, col_indices), self.history_item_value[user].flatten()
-        )
-        return rating_matrix
 
     def mlp_layers(self, layer_dims):
         mlp_modules = []

--- a/recbole/model/general_recommender/multidae.py
+++ b/recbole/model/general_recommender/multidae.py
@@ -15,13 +15,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from recbole.model.abstract_recommender import GeneralRecommender
+from recbole.model.abstract_recommender import AutoEncoderMixin, GeneralRecommender
 from recbole.model.init import xavier_normal_initialization
 from recbole.model.layers import MLPLayers
 from recbole.utils import InputType
 
 
-class MultiDAE(GeneralRecommender):
+class MultiDAE(GeneralRecommender, AutoEncoderMixin):
     r"""MultiDAE is an item-based collaborative filtering model that simultaneously ranks all items for each user.
 
     We implement the the MultiDAE model with only user dataloader.
@@ -35,9 +35,7 @@ class MultiDAE(GeneralRecommender):
         self.lat_dim = config["latent_dimension"]
         self.drop_out = config["dropout_prob"]
 
-        self.history_item_id, self.history_item_value, _ = dataset.history_item_matrix()
-        self.history_item_id = self.history_item_id.to(self.device)
-        self.history_item_value = self.history_item_value.to(self.device)
+        self.build_histroy_items(dataset)
 
         self.encode_layer_dims = [self.n_items] + self.layers + [self.lat_dim]
         self.decode_layer_dims = [self.lat_dim] + self.encode_layer_dims[::-1][1:]
@@ -47,30 +45,6 @@ class MultiDAE(GeneralRecommender):
 
         # parameters initialization
         self.apply(xavier_normal_initialization)
-
-    def get_rating_matrix(self, user):
-        r"""Get a batch of user's feature with the user's id and history interaction matrix.
-
-        Args:
-            user (torch.LongTensor): The input tensor that contains user's id, shape: [batch_size, ]
-
-        Returns:
-            torch.FloatTensor: The user's feature of a batch of user, shape: [batch_size, n_items]
-        """
-        # Following lines construct tensor of shape [B,n_items] using the tensor of shape [B,H]
-        col_indices = self.history_item_id[user].flatten()
-        row_indices = (
-            torch.arange(user.shape[0])
-            .to(self.device)
-            .repeat_interleave(self.history_item_id.shape[1], dim=0)
-        )
-        rating_matrix = (
-            torch.zeros(1).to(self.device).repeat(user.shape[0], self.n_items)
-        )
-        rating_matrix.index_put_(
-            (row_indices, col_indices), self.history_item_value[user].flatten()
-        )
-        return rating_matrix
 
     def mlp_layers(self, layer_dims):
         mlp_modules = []

--- a/recbole/model/general_recommender/recvae.py
+++ b/recbole/model/general_recommender/recvae.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from recbole.model.abstract_recommender import GeneralRecommender
+from recbole.model.abstract_recommender import GeneralRecommender, AutoEncoderMixin
 from recbole.model.init import xavier_normal_initialization
 from recbole.utils import InputType
 
@@ -104,7 +104,7 @@ class Encoder(nn.Module):
         return self.fc_mu(h5), self.fc_logvar(h5)
 
 
-class RecVAE(GeneralRecommender):
+class RecVAE(GeneralRecommender, AutoEncoderMixin):
     r"""Collaborative Denoising Auto-Encoder (RecVAE) is a recommendation model
     for top-N recommendation with implicit feedback.
 
@@ -122,9 +122,7 @@ class RecVAE(GeneralRecommender):
         self.mixture_weights = config["mixture_weights"]
         self.gamma = config["gamma"]
 
-        self.history_item_id, self.history_item_value, _ = dataset.history_item_matrix()
-        self.history_item_id = self.history_item_id.to(self.device)
-        self.history_item_value = self.history_item_value.to(self.device)
+        self.build_histroy_items(dataset)
 
         self.encoder = Encoder(self.hidden_dim, self.latent_dim, self.n_items)
         self.prior = CompositePrior(
@@ -134,30 +132,6 @@ class RecVAE(GeneralRecommender):
 
         # parameters initialization
         self.apply(xavier_normal_initialization)
-
-    def get_rating_matrix(self, user):
-        r"""Get a batch of user's feature with the user's id and history interaction matrix.
-
-        Args:
-            user (torch.LongTensor): The input tensor that contains user's id, shape: [batch_size, ]
-
-        Returns:
-            torch.FloatTensor: The user's feature of a batch of user, shape: [batch_size, n_items]
-        """
-        # Following lines construct tensor of shape [B,n_items] using the tensor of shape [B,H]
-        col_indices = self.history_item_id[user].flatten()
-        row_indices = (
-            torch.arange(user.shape[0])
-            .to(self.device)
-            .repeat_interleave(self.history_item_id.shape[1], dim=0)
-        )
-        rating_matrix = (
-            torch.zeros(1).to(self.device).repeat(user.shape[0], self.n_items)
-        )
-        rating_matrix.index_put_(
-            (row_indices, col_indices), self.history_item_value[user].flatten()
-        )
-        return rating_matrix
 
     def reparameterize(self, mu, logvar):
         if self.training:


### PR DESCRIPTION

Hi. I'm a newbie to Recbole. When I try to use autoencoder method Mult-VAE on Movielens-20m with GPU, OOM issue keeps coming up.

After I check the code, I noticed that several autoencoder methods (cdae, macridvae, multidae, multivae, ract, recvae) will load all the interaction in training set to cuda in `__init__`, and this requires lots of memory for dataset with tens of millions interactions.

So I think maybe it's a good idea that we do not set history items to cuda, and only set rating matrix to cuda when `get_rating_matrix` is called. This way, I can run movielens-20m on Tesla k80 easily.

And since these AutoEncoders share same behavior, so I create a Mixin class that all these auto encoders can inherit.

Below is a simple speed test, I run mult-vae on Movielens-100k, with both CPU (macOS, python 3.7.5) and GPU (EC2 p2.8xlarge, with single GPU, python 3.7.10), each setting is run 10 times and the running time is recorded.

Follwing is my setting:

```
from recbole.quick_start import run_recbole
run_recbole(model='MultiVAE', dataset='ml-100k', config_dict={'epochs': 100, 'stopping_step':1e8})
```

And heres the result:

original(5c07ac44c56641c5bbe9aea04d7d2a554494c698):
* CPU: 112.56 sec 
* GPU: 198.96 sec

my version (do not to cuda in `__init__`):
* CPU: 104.29 sec
* GPU: 186.79 sec
