### PR TITLE
Update interaction.py

### DIFF
--- a/recbole/data/interaction.py
+++ b/recbole/data/interaction.py
@@ -342,9 +342,9 @@ class Interaction(object):
                 key = self.interaction[b]
             else:
                 key = self.interaction[b][..., 0]
-            index = np.array(np.argsort(key, kind="stable"))
+            index = np.argsort(key, kind="stable")
             if not a:
-                index = index[::-1].copy()
+                index = torch.tensor(np.array(index)[::-1])
             self._reindex(index)
 
     def add_prefix(self, prefix):

--- a/recbole/data/interaction.py
+++ b/recbole/data/interaction.py
@@ -342,9 +342,9 @@ class Interaction(object):
                 key = self.interaction[b]
             else:
                 key = self.interaction[b][..., 0]
-            index = np.argsort(key, kind="stable")
+            index = np.array(np.argsort(key, kind="stable"))
             if not a:
-                index = index[::-1]
+                index = index[::-1].copy()
             self._reindex(index)
 
     def add_prefix(self, prefix):


### PR DESCRIPTION
after `np.argsort`, the index is a tensor, thus can not be sliced by negative stride: `[::-1]`. Need to transform index into NumPy array explicitly.
Also, `[::-1]` is only a view, `[::-1].copy()` makes it compatible with `_reindex()`.