### PR TITLE
update np.float to np.float64

### DIFF
--- a/recbole/evaluator/metrics.py
+++ b/recbole/evaluator/metrics.py
@@ -87,7 +87,7 @@ class MRR(TopkMetric):
 
     def metric_info(self, pos_index):
         idxs = pos_index.argmax(axis=1)
-        result = np.zeros_like(pos_index, dtype=np.float)
+        result = np.zeros_like(pos_index, dtype=np.float64)
         for row, idx in enumerate(idxs):
             if pos_index[row, idx] > 0:
                 result[row, idx:] = 1 / (idx + 1)
@@ -125,10 +125,12 @@ class MAP(TopkMetric):
 
     def metric_info(self, pos_index, pos_len):
         pre = pos_index.cumsum(axis=1) / np.arange(1, pos_index.shape[1] + 1)
-        sum_pre = np.cumsum(pre * pos_index.astype(np.float), axis=1)
+        sum_pre = np.cumsum(pre * pos_index.astype(
+        
+        ), axis=1)
         len_rank = np.full_like(pos_len, pos_index.shape[1])
         actual_len = np.where(pos_len > len_rank, len_rank, pos_len)
-        result = np.zeros_like(pos_index, dtype=np.float)
+        result = np.zeros_like(pos_index, dtype=np.float64)
         for row, lens in enumerate(actual_len):
             ranges = np.arange(1, pos_index.shape[1] + 1)
             ranges[lens:] = ranges[lens - 1]
@@ -187,13 +189,13 @@ class NDCG(TopkMetric):
         len_rank = np.full_like(pos_len, pos_index.shape[1])
         idcg_len = np.where(pos_len > len_rank, len_rank, pos_len)
 
-        iranks = np.zeros_like(pos_index, dtype=np.float)
+        iranks = np.zeros_like(pos_index, dtype=np.float64)
         iranks[:, :] = np.arange(1, pos_index.shape[1] + 1)
         idcg = np.cumsum(1.0 / np.log2(iranks + 1), axis=1)
         for row, idx in enumerate(idcg_len):
             idcg[row, idx:] = idcg[row, idx - 1]
 
-        ranks = np.zeros_like(pos_index, dtype=np.float)
+        ranks = np.zeros_like(pos_index, dtype=np.float64)
         ranks[:, :] = np.arange(1, pos_index.shape[1] + 1)
         dcg = 1.0 / np.log2(ranks + 1)
         dcg = np.cumsum(np.where(pos_index, dcg, 0), axis=1)


### PR DESCRIPTION
numpy >= 1.20 doesn't support dtype=np.float, this causes failure when running metrics.py
I updated all np.float to np.float64
```
  File "/opt/anaconda3/envs/recbole/lib/python3.9/site-packages/recbole/evaluator/metrics.py", line 190, in metric_info
    iranks = np.zeros_like(pos_index, dtype=np.float)
  File "/opt/anaconda3/envs/recbole/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```