### PR TITLE
added .to(self.device) - bug fixed for SLIMElastic

### DIFF
--- a/recbole/evaluator/collector.py
+++ b/recbole/evaluator/collector.py
@@ -91,7 +91,7 @@ class Collector(object):
         if self.register.need("data.count_items"):
             self.data_struct.set("data.count_items", train_data._dataset.item_counter)
         if self.register.need("data.count_users"):
-            self.data_struct.set("data.count_items", train_data._dataset.user_counter)
+            self.data_struct.set("data.count_users", train_data._dataset.user_counter)
 
     def _average_rank(self, scores):
         """Get the ranking of an ordered tensor, and take the average of the ranking for positions with equal values.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 torch>=1.10.0
 numpy>=1.17.2
 scipy>=1.6.0
-hyperopt==0.2.5
 pandas>=1.4.0
 tqdm>=4.48.2
 scikit_learn>=0.23.2


### PR DESCRIPTION
With this changes, I solved a bug related to the model `SLIMElastic`; I found issues related to the instruction with `torch.cat()` in this file, the tensor seemed to be partially on the GPU and partially on the CPU. This solved.

Moreover, this source code includes the fix for the bug reported in [this issue](https://github.com/RUCAIBox/RecBole/issues/1743#issue-1676907284).
