### PR TITLE
FIX: improve the performance of accessing dataset

### DIFF
--- a/run_example/recbole-using-all-items-for-prediction.ipynb
+++ b/run_example/recbole-using-all-items-for-prediction.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f0100cdc",
    "metadata": {
@@ -54,6 +55,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "bbb84f80",
    "metadata": {
@@ -590,6 +592,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d0f27239",
    "metadata": {
@@ -761,6 +764,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c1127367",
    "metadata": {
@@ -856,6 +860,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3a74f096",
    "metadata": {
@@ -1099,6 +1104,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e61e4796",
    "metadata": {
@@ -1190,6 +1196,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "dfa2bf97",
    "metadata": {
@@ -1252,6 +1259,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "352b35aa",
    "metadata": {
@@ -1308,6 +1316,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c9749297",
    "metadata": {
@@ -1393,6 +1402,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3a4ebb13",
    "metadata": {
@@ -1419,6 +1429,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0da61c25",
    "metadata": {
@@ -1436,6 +1447,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "642300a0",
    "metadata": {
@@ -1592,6 +1604,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f22ab4c5",
    "metadata": {
@@ -1660,6 +1673,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0349a339",
    "metadata": {
@@ -1736,6 +1750,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "61a9aaa8",
    "metadata": {
@@ -1785,6 +1800,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9d7071fb",
    "metadata": {
@@ -1829,8 +1845,9 @@
     "\n",
     "def add_last_item(old_interaction, last_item_id, max_len=50):\n",
     "    new_seq_items = old_interaction['item_id_list'][-1]\n",
-    "    if old_interaction['item_length'][-1].item() < max_len:\n",
-    "        new_seq_items[old_interaction['item_length'][-1].item()] = last_item_id\n",
+    "    item_length = old_interaction['item_length'][-1].item()\n",
+    "    if item_length < max_len:\n",
+    "        new_seq_items[item_length] = last_item_id\n",
     "    else:\n",
     "        new_seq_items = torch.roll(new_seq_items, -1)\n",
     "        new_seq_items[-1] = last_item_id\n",
@@ -1841,7 +1858,10 @@
     "    with torch.no_grad():\n",
     "        uid_series = dataset.token2id(dataset.uid_field, [external_user_id])\n",
     "        index = np.isin(dataset[dataset.uid_field].numpy(), uid_series)\n",
-    "        input_interaction = dataset[index]\n",
+    "\n",
+    "        # instead of passing in a bool array whose shape is the same with dataset,\n",
+    "        # we just filter the corresponding index to pass in, then we get great performance improvements.\n",
+    "        input_interaction = dataset[index.nonzero()] \n",
     "        test = {\n",
     "            'item_id_list': add_last_item(input_interaction, \n",
     "                                          input_interaction['item_id'][-1].item(), model.max_seq_length),\n",
@@ -1900,6 +1920,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9c7564dc",
    "metadata": {


### PR DESCRIPTION
Improve the performance of recbole-using-all-items-for-prediction.ipynb
In practice, I found that the operation of the code in this file was very time-consuming in the prediction task. After debugging, I found that the access time of dataset[index] took a large proportion. When dataset is large, index would be a bool array with the same size as dataset. So I first selected the corresponding subscript, directly take out the corresponding element in the dataset, which will greatly improve 10 times of the performance on ml-100k dataset.
![屏幕截图 2023-05-09 222555](https://github.com/RUCAIBox/RecBole/assets/95904690/0bdc4e05-fd65-4aa0-b549-580f60be984e)
![屏幕截图 2023-05-09 222655](https://github.com/RUCAIBox/RecBole/assets/95904690/b59cb76b-9f3c-4816-8d16-7d736a2ae74c)