### PR TITLE
Include Amazon-M2 dataset [KDD Cup 2023]

### DIFF
--- a/recbole/properties/dataset/url.yaml
+++ b/recbole/properties/dataset/url.yaml
@@ -56,6 +56,7 @@ amazon-toys-games-18: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatas
 amazon-video-games-18: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatasets/Amazon_ratings/Amazon2018/Amazon_Video_Games.zip
 anime: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatasets/Anime/anime.zip
 avazu: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatasets/Avazu/avazu.zip
+amazon-m2: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatasets/Amazon_M2/amazon_m2.zip
 beeradvocate: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatasets/BeerAdvocate/BeerAdvocate.zip
 behance: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatasets/Behance/Behance.zip
 book-crossing: https://recbole.s3-accelerate.amazonaws.com/ProcessedDatasets/Book-Crossing/book-crossing.zip


### PR DESCRIPTION
Credit to Wei @ChandlerBang, Haitao @HaitaoMao, et al., thanks!

Include a new dataset named **Amazon-M2**, originally contributed by Wei et al. "Amazon-M2: A Multilingual Multi-locale Shopping Session Dataset for Recommendation and Text Generation." [[arXiv](https://arxiv.org/abs/2307.09688)], which has been used in the [Amazon KDD Cup '23: Multilingual Recommendation Challenge](https://www.aicrowd.com/challenges/amazon-kdd-cup-23-multilingual-recommendation-challenge).

Files have been processed into atomic files and uploaded to [Google Drive](https://drive.google.com/drive/folders/16NIkXd5KerLeBifW0cuIeVZ33vzjYOz8?usp=drive_link). Besides, downloading link has been added by indicating the dataset as `amazon-m2`.