### PR TITLE
[🐛Bug] Fix `if` condition in `set_neg_sample_args` function

### DIFF
--- a/recbole/data/dataloader/abstract_dataloader.py
+++ b/recbole/data/dataloader/abstract_dataloader.py
@@ -136,8 +136,7 @@ class NegSampleDataLoader(AbstractDataLoader):
         self.neg_sample_args = neg_sample_args
         self.times = 1
         if (
-            self.neg_sample_args["distribution"] == "uniform"
-            or "popularity"
+            self.neg_sample_args["distribution"] in ["uniform", "popularity"]
             and self.neg_sample_args["sample_num"] != "none"
         ):
             self.neg_sample_num = self.neg_sample_args["sample_num"]


### PR DESCRIPTION
In the current version
https://github.com/RUCAIBox/RecBole/blob/2c6f066eb1e87814bb5101eb727b1308661e030c/recbole/data/dataloader/abstract_dataloader.py#L139-L140
The `if` condition is still `true` when `distribution` is `uniform` but `sample_num` is `none`.