### PR TITLE
[🐛 BUG] Incorrect evaluation results due to multi-GPU distributed sampler

### DIFF
--- a/recbole/trainer/trainer.py
+++ b/recbole/trainer/trainer.py
@@ -579,7 +579,8 @@ class Trainer(AbstractTrainer):
 
         if load_best_model:
             # Refer to: https://pytorch.org/tutorials/intermediate/ddp_tutorial.html#save-and-load-checkpoints
-            dist.barrier()
+            if not self.config["single_spec"]:
+                dist.barrier()
             checkpoint_file = model_file or self.saved_model_file
             map_location = {"cuda:%d" % 0: "cuda:%d" % self.config["local_rank"]}
             checkpoint = torch.load(checkpoint_file, map_location=map_location)

--- a/recbole/trainer/trainer.py
+++ b/recbole/trainer/trainer.py
@@ -608,9 +608,7 @@ class Trainer(AbstractTrainer):
             else eval_data
         )
 
-        num_sample = 0
         for batch_idx, batched_data in enumerate(iter_data):
-            num_sample += len(batched_data)
             interaction, scores, positive_u, positive_i = eval_func(batched_data)
             if self.gpu_available and show_progress:
                 iter_data.set_postfix_str(

--- a/recbole/utils/utils.py
+++ b/recbole/utils/utils.py
@@ -48,8 +48,7 @@ def ensure_dir(dir_path):
         dir_path (str): directory path
 
     """
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
+    os.makedirs(dir_path, exist_ok=True)
 
 
 def get_model(model_name):


### PR DESCRIPTION
# Bug description

## 1. Duplicate sampling in `DistributedSampler`
https://github.com/RUCAIBox/RecBole/blob/f9104dc89ba7d61606267f6909b7ab4297521190/recbole/data/dataloader/abstract_dataloader.py#L59-L64

The `torch.utils.data.distributed.DistributedSampler` used in `AbstractDataLoader` pads the number of samples to make it divisible by the number of processes. Then here `DsitributedSampler` **duplicates** the last few samples if `drop_last` is `False`.

For example, suppose we have 10 samples and train models on 3 GPUs.

Then, it is likely that we will get the following partitions:
GPU 1: **1**, 4, 7, **0**
GPU 2: **0**, 3, 6, 9
GPU 3: 2, 5, 8, **1**

So, you will find that in order for each GPU to get the same amount of data, the sampler is repeatedly allocated 1 and 0 to different GPUs. 

And let's check the evaluation logic in DDP mode:
https://github.com/RUCAIBox/RecBole/blob/f9104dc89ba7d61606267f6909b7ab4297521190/recbole/trainer/trainer.py#L630-L652

Basically, it takes this way to recalculate the final evaluation result:

$$ \text{final value} = \frac {\text{value} \times \text{num sample}}{\text{total sample}} $$

**This can cause serious bugs because $\text{total sample}$ has changed to 12 instead of 10.**

## 2. Incorrect way to get `num_sample`.

https://github.com/RUCAIBox/RecBole/blob/f9104dc89ba7d61606267f6909b7ab4297521190/recbole/trainer/trainer.py#L613

This line tries to get the number of samples in each `batched_data`, however, it is unable to get the correct value since `batched_data` is a `tuple` and its length is not the number of samples.

# Fix

## 1. Implement `NoDuplicateDistributedSampler`
Referring to https://github.com/pytorch/pytorch/issues/25162#issuecomment-1227647626, I implemented a `NoDuplicateDistributedSampler`. It will partition the samples **unevenly** into different GPUs, e.g., [1, 4, 7, 0], [3, 6, 9], [2, 5, 8].

## 2. Correct way to get `num_sample`.

We can get the `num_samples` and `total_size` in `eval_data.sampler`. Then we don't have to gather and calculate them from different GPUs, i.e., 

```python
num_samples = eval_data.sampler.num_samples
total_size = eval_data.sampler.total_size
```

# Existing Limitation and Future Work [Done]
**Original Bug**: The evaluation recalculation method as mentioned above only works for those metrics following the same way, e.g., `MAE`, `Recall`, `Precision`. However, some metrics are not working in this way, e.g., `Gini Index`, `Shannon Entropy`, and `Item Coverage`.

~~I'm investigating other methods of calculation but I can only do this first because of time constraints.~~
**✨ I've found a new way to calculate the evaluation metrics:**

We can gather `data struct` (e.g., `rec.items`, `rec.score`) from all GPUs first and then calculate the result using the `self.evaluator.evaluate(struct)` function (`_map_reduce()` will be obsolete).

Then we can get consistent results as running on a single GPU.

I will keep updating this PR.
And please let me know if I've thought anything wrong.

Thanks! 💪