### PR TITLE
[🐛 BUG] Fix bugs when collecting results from `mp.spawn` in multi-GPU training

### DIFF
--- a/docs/source/get_started/distributed_training.rst
+++ b/docs/source/get_started/distributed_training.rst
@@ -121,20 +121,32 @@ In above example, you can create a new python file (e.g., `run_a.py`) on node A,
         nproc = 4,
         group_offset = 0
     )
+
+    # Optional, only needed if you want to get the result of each process.
+    queue = mp.get_context('spawn').SimpleQueue()
+
+    config_dict = config_dict or {}
+    config_dict.update({
+        "world_size": args.world_size,
+        "ip": args.ip,
+        "port": args.port,
+        "nproc": args.nproc,
+        "offset": args.group_offset,
+    })
+    kwargs = {
+        "config_dict": config_dict,
+        "queue": queue, # Optional
+    }
+
     mp.spawn(
         run_recboles,
-        args=(
-            args.model,
-            args.dataset,
-            config_file_list,
-            args.ip,
-            args.port,
-            args.world_size,
-            args.nproc,
-            args.group_offset,
-        ),
-        nprocs=args.nproc,
+        args=(args.model, args.dataset, args.config_file_list, kwargs),
+        nprocs=nproc,
+        join=True,
     )
+
+    # Normally, there should be only one item in the queue
+    res = None if queue.empty() else queue.get()
 
 
 Then run the following command:
@@ -159,20 +171,32 @@ Similarly, you can create a new python file (e.g., `run_b.py`) on node B, and wr
         nproc = 4,
         group_offset = 4
     )
+
+    # Optional, only needed if you want to get the result of each process.
+    queue = mp.get_context('spawn').SimpleQueue()
+
+    config_dict = config_dict or {}
+    config_dict.update({
+        "world_size": args.world_size,
+        "ip": args.ip,
+        "port": args.port,
+        "nproc": args.nproc,
+        "offset": args.group_offset,
+    })
+    kwargs = {
+        "config_dict": config_dict,
+        "queue": queue, # Optional
+    }
+
     mp.spawn(
         run_recboles,
-        args=(
-            args.model,
-            args.dataset,
-            config_file_list,
-            args.ip,
-            args.port,
-            args.world_size,
-            args.nproc,
-            args.group_offset,
-        ),
-        nprocs=args.nproc,
+        args=(args.model, args.dataset, args.config_file_list, kwargs),
+        nprocs=nproc,
+        join=True,
     )
+
+    # Normally, there should be only one item in the queue
+    res = None if queue.empty() else queue.get()
 
 
 Then run the following command:

--- a/recbole/quick_start/__init__.py
+++ b/recbole/quick_start/__init__.py
@@ -1,4 +1,5 @@
 from recbole.quick_start.quick_start import (
+    run,
     run_recbole,
     objective_function,
     load_data_and_model,

--- a/recbole/quick_start/quick_start.py
+++ b/recbole/quick_start/quick_start.py
@@ -173,18 +173,12 @@ def run_recbole(
 
 
 def run_recboles(rank, *args):
-    ip, port, world_size, nproc, offset = args[3:]
-    args = args[:3]
+    kwargs = args[-1]
+    kwargs["config_dict"] = kwargs.get("config_dict", {})
+    kwargs["config_dict"]["local_rank"] = rank
     run_recbole(
-        *args,
-        config_dict={
-            "local_rank": rank,
-            "world_size": world_size,
-            "ip": ip,
-            "port": port,
-            "nproc": nproc,
-            "offset": offset,
-        },
+        *args[:3],
+        **kwargs,
     )
 
 

--- a/recbole/quick_start/quick_start.py
+++ b/recbole/quick_start/quick_start.py
@@ -13,6 +13,7 @@ recbole.quick_start
 """
 import logging
 import sys
+import torch.distributed as dist
 from collections.abc import MutableMapping
 from logging import getLogger
 
@@ -168,6 +169,9 @@ def run_recbole(
         "best_valid_result": best_valid_result,
         "test_result": test_result,
     }
+
+    if not config["single_spec"]:
+        dist.destroy_process_group()
 
     if config["local_rank"] == 0 and queue is not None:
         queue.put(result)  # for multiprocessing, e.g., mp.spawn

--- a/recbole/quick_start/quick_start.py
+++ b/recbole/quick_start/quick_start.py
@@ -39,8 +39,62 @@ from recbole.utils import (
 )
 
 
+def run(
+    model,
+    dataset,
+    config_file_list=None,
+    config_dict=None,
+    saved=True,
+    nproc=1,
+    world_size=-1,
+    ip="localhost",
+    port="5678",
+    group_offset=0,
+):
+    if nproc == 1 and world_size <= 0:
+        res = run_recbole(
+            model=model,
+            dataset=dataset,
+            config_file_list=config_file_list,
+            config_dict=config_dict,
+            saved=saved,
+        )
+    else:
+        if world_size == -1:
+            world_size = nproc
+        import torch.multiprocessing as mp
+
+        # Refer to https://discuss.pytorch.org/t/problems-with-torch-multiprocess-spawn-and-simplequeue/69674/2
+        # https://discuss.pytorch.org/t/return-from-mp-spawn/94302/2
+        queue = mp.get_context('spawn').SimpleQueue()
+
+        config_dict = config_dict or {}
+        config_dict.update({
+            "world_size": world_size,
+            "ip": ip,
+            "port": port,
+            "nproc": nproc,
+            "offset": group_offset,
+        })
+        kwargs = {
+            "config_dict": config_dict,
+            "queue": queue,
+        }
+
+        mp.spawn(
+            run_recboles,
+            args=(model, dataset, config_file_list, kwargs),
+            nprocs=nproc,
+            join=True,
+        )
+
+        # Normally, there should be only one item in the queue
+        res = None if queue.empty() else queue.get()
+    return res
+
+
 def run_recbole(
-    model=None, dataset=None, config_file_list=None, config_dict=None, saved=True
+    model=None, dataset=None, config_file_list=None, config_dict=None, saved=True, queue=None
 ):
     r"""A fast running api, which includes the complete process of
     training and testing a model on a specified dataset
@@ -51,6 +105,7 @@ def run_recbole(
         config_file_list (list, optional): Config files used to modify experiment parameters. Defaults to ``None``.
         config_dict (dict, optional): Parameters dictionary used to modify experiment parameters. Defaults to ``None``.
         saved (bool, optional): Whether to save the model. Defaults to ``True``.
+        queue (torch.multiprocessing.Queue, optional): The queue used to pass the result to the main process. Defaults to ``None``.
     """
     # configurations initialization
     config = Config(
@@ -104,12 +159,17 @@ def run_recbole(
     logger.info(set_color("best valid ", "yellow") + f": {best_valid_result}")
     logger.info(set_color("test result", "yellow") + f": {test_result}")
 
-    return {
+    result = {
         "best_valid_score": best_valid_score,
         "valid_score_bigger": config["valid_metric_bigger"],
         "best_valid_result": best_valid_result,
         "test_result": test_result,
     }
+
+    if config["local_rank"] == 0 and queue is not None:
+        queue.put(result)  # for multiprocessing, e.g., mp.spawn
+
+    return result # for the single process
 
 
 def run_recboles(rank, *args):

--- a/run_recbole.py
+++ b/run_recbole.py
@@ -8,9 +8,8 @@
 # @Email  : chenyuwuxinn@gmail.com, houyupeng@ruc.edu.cn, zhlin@ruc.edu.cn
 
 import argparse
-from ast import arg
 
-from recbole.quick_start import run_recbole, run_recboles
+from recbole.quick_start import run
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -44,26 +43,13 @@ if __name__ == "__main__":
         args.config_files.strip().split(" ") if args.config_files else None
     )
 
-    if args.nproc == 1 and args.world_size <= 0:
-        run_recbole(
-            model=args.model, dataset=args.dataset, config_file_list=config_file_list
-        )
-    else:
-        if args.world_size == -1:
-            args.world_size = args.nproc
-        import torch.multiprocessing as mp
-
-        mp.spawn(
-            run_recboles,
-            args=(
-                args.model,
-                args.dataset,
-                config_file_list,
-                args.ip,
-                args.port,
-                args.world_size,
-                args.nproc,
-                args.group_offset,
-            ),
-            nprocs=args.nproc,
-        )
+    run(
+        args.model,
+        args.dataset,
+        config_file_list=config_file_list,
+        nproc=args.nproc,
+        world_size=args.world_size,
+        ip=args.ip,
+        port=args.port,
+        group_offset=args.group_offset,
+    )

--- a/run_recbole_group.py
+++ b/run_recbole_group.py
@@ -4,40 +4,9 @@
 
 
 import argparse
-from ast import arg
 
-from recbole.quick_start import run_recbole, run_recboles
+from recbole.quick_start import run
 from recbole.utils import list_to_latex
-
-
-def run(args, model, config_file_list):
-    if args.nproc == 1 and args.world_size <= 0:
-        res = run_recbole(
-            model=model,
-            dataset=args.dataset,
-            config_file_list=config_file_list,
-        )
-    else:
-        if args.world_size == -1:
-            args.world_size = args.nproc
-        import torch.multiprocessing as mp
-
-        res = mp.spawn(
-            run_recboles,
-            args=(
-                args.model,
-                args.dataset,
-                config_file_list,
-                args.ip,
-                args.port,
-                args.world_size,
-                args.nproc,
-                args.group_offset,
-            ),
-            nprocs=args.nproc,
-        )
-    return res
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -92,7 +61,16 @@ if __name__ == "__main__":
 
         valid_res_dict = {"Model": model}
         test_res_dict = {"Model": model}
-        result = run(args, model, config_file_list)
+        result = run(
+            model,
+            args.dataset,
+            config_file_list=config_file_list,
+            nproc=args.nproc,
+            world_size=args.world_size,
+            ip=args.ip,
+            port=args.port,
+            group_offset=args.group_offset,
+        )
         valid_res_dict.update(result["best_valid_result"])
         test_res_dict.update(result["test_result"])
         bigger_flag = result["valid_score_bigger"]


### PR DESCRIPTION
# Bug description

We are unable to collect results directly from `mp.spawn`, e.g., 
https://github.com/RUCAIBox/RecBole/blob/96eb311b029c0a399df452cbc612460e8f87d44e/run_recbole_group.py#L25-L38

[torch.multiprocessing.Queue](https://pytorch.org/docs/stable/notes/multiprocessing.html#reuse-buffers-passed-through-a-queue) can be applied for this purpose.

# Changelog in this PR

1. Fixd result collection bug when using `mp.spawn`;
2. Updated documents of `distributed training`;
3. Fix bugs in [significance_test.py](https://github.com/RUCAIBox/RecBole/blob/master/significance_test.py)