### PR TITLE
Fixed dropout instantiation in NGCF and GRU4RecKG forward. Moved dropout_prob in config for SimpleX.

### DIFF
--- a/recbole/model/general_recommender/ngcf.py
+++ b/recbole/model/general_recommender/ngcf.py
@@ -56,6 +56,7 @@ class NGCF(GeneralRecommender):
         self.sparse_dropout = SparseDropout(self.node_dropout)
         self.user_embedding = nn.Embedding(self.n_users, self.embedding_size)
         self.item_embedding = nn.Embedding(self.n_items, self.embedding_size)
+        self.emb_dropout = nn.Dropout(self.message_dropout)
         self.GNNlayers = torch.nn.ModuleList()
         for idx, (input_size, output_size) in enumerate(
             zip(self.hidden_size_list[:-1], self.hidden_size_list[1:])
@@ -156,7 +157,7 @@ class NGCF(GeneralRecommender):
         for gnn in self.GNNlayers:
             all_embeddings = gnn(A_hat, self.eye_matrix, all_embeddings)
             all_embeddings = nn.LeakyReLU(negative_slope=0.2)(all_embeddings)
-            all_embeddings = nn.Dropout(self.message_dropout)(all_embeddings)
+            all_embeddings = self.emb_dropout(all_embeddings)
             all_embeddings = F.normalize(all_embeddings, p=2, dim=1)
             embeddings_list += [
                 all_embeddings

--- a/recbole/model/general_recommender/simplex.py
+++ b/recbole/model/general_recommender/simplex.py
@@ -73,7 +73,7 @@ class SimpleX(GeneralRecommender):
             if self.aggregator == "self_attention":
                 self.W_q = nn.Linear(self.embedding_size, 1, bias=False)
         # dropout
-        self.dropout = nn.Dropout(0.1)
+        self.dropout_prob = nn.Dropout(config["dropout_prob"])
         self.require_pow = config["require_pow"]
         # l2 regularization loss
         self.reg_loss = EmbLoss()

--- a/recbole/model/knowledge_aware_recommender/mkr.py
+++ b/recbole/model/knowledge_aware_recommender/mkr.py
@@ -73,7 +73,7 @@ class MKR(KnowledgeRecommender):
         self.kge_pred_mlp = MLPLayers(
             [self.embedding_size * 2, self.embedding_size], self.dropout_prob, "sigmoid"
         )
-        if self.use_inner_product == False:
+        if not self.use_inner_product:
             self.rs_pred_mlp = MLPLayers(
                 [self.embedding_size * 2, 1], self.dropout_prob, "sigmoid"
             )

--- a/recbole/model/sequential_recommender/gru4reckg.py
+++ b/recbole/model/sequential_recommender/gru4reckg.py
@@ -47,6 +47,8 @@ class GRU4RecKG(SequentialRecommender):
         self.entity_embedding = nn.Embedding(
             self.n_items, self.embedding_size, padding_idx=0
         )
+        self.item_emb_dropout = nn.Dropout(self.dropout)
+        self.entity_emb_dropout = nn.Dropout(self.dropout)
         self.entity_embedding.weight.requires_grad = not self.freeze_kg
         self.item_gru_layers = nn.GRU(
             input_size=self.embedding_size,
@@ -79,8 +81,8 @@ class GRU4RecKG(SequentialRecommender):
     def forward(self, item_seq, item_seq_len):
         item_emb = self.item_embedding(item_seq)
         entity_emb = self.entity_embedding(item_seq)
-        item_emb = nn.Dropout(self.dropout)(item_emb)
-        entity_emb = nn.Dropout(self.dropout)(entity_emb)
+        item_emb = self.item_emb_dropout(item_emb)
+        entity_emb = self.entity_emb_dropout(entity_emb)
 
         item_gru_output, _ = self.item_gru_layers(item_emb)  # [B Len H]
         entity_gru_output, _ = self.entity_gru_layers(entity_emb)

--- a/recbole/properties/model/SimpleX.yaml
+++ b/recbole/properties/model/SimpleX.yaml
@@ -5,3 +5,4 @@ gamma: 0.5                      # (float) Weight for fusion of user' and interac
 aggregator: 'mean'              # (str) The item aggregator ranging in ['mean', 'user_attention', 'self_attention'].
 history_len: 50                 # (int) The length of the user's historical interaction items.
 reg_weight: 1e-05               # (float) The L2 regularization weights.
+dropout_prob: 0.1               # (float) Dropout probability for fusion of user' and interacted items' representations.


### PR DESCRIPTION
Some models were directly instantiating a dropout object in the forward function, such as NGCF. Calling model.eval() does not turn off dropout in these scenarios, leading to potential issues in the case a direct access to the forward function is done for whatever use.

For one of my projects, I indeed needed to regenerate the user and item embeddings by keeping constant the trained weights, but the predictions were inconsistent due to this issue.

I found this issue in NGCF and GRU4RecKG. While checking all the models, I also noticed that the dropout probability for SimpleX was hard-coded as 0.1, and I moved it to its config file.