### PR TITLE
Correct random state w.r.t. the newest version of hyperopt

### DIFF
--- a/recbole/trainer/hyper_tuning.py
+++ b/recbole/trainer/hyper_tuning.py
@@ -114,7 +114,7 @@ def exhaustive_search(new_ids, domain, trials, seed, nbMaxSucessiveFailures=1000
         ]
     )
 
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed=seed)
     rval = []
     for _, new_id in enumerate(new_ids):
         newSample = False


### PR DESCRIPTION
The method np.random.RandomState was deprecated. Hyperopt now uses np.random.Generator().
