### PR TITLE
Fix numpy version in requirements.txt to be compatible with ray

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.10.0
-numpy>=1.17.2
+numpy>=1.17.2, <=1.23.5
 scipy>=1.6.0
 hyperopt==0.2.5
 pandas>=1.3.0


### PR DESCRIPTION
The quick start currently produces an error (see message below) -- this is due to the most recent version of numpy being installed, which is incompatible with the version of ray used in RecBole. Fixing `numpy` to be `<=1.23.5` fixes the issue


```shell
(.venv) bschroeder@FTG291XHF4 RecBole % python run_recbole.py
/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
Traceback (most recent call last):
  File "/Users/bschroeder/RecBole/run_recbole.py", line 12, in <module>
    from recbole.quick_start import run
  File "/Users/bschroeder/RecBole/recbole/quick_start/__init__.py", line 1, in <module>
    from recbole.quick_start.quick_start import (
  File "/Users/bschroeder/RecBole/recbole/quick_start/quick_start.py", line 20, in <module>
    from ray import tune
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/__init__.py", line 2, in <module>
    from ray.tune.tune import run_experiments, run
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/tune.py", line 31, in <module>
    from ray.tune.analysis import ExperimentAnalysis
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/analysis/__init__.py", line 1, in <module>
    from ray.tune.analysis.experiment_analysis import ExperimentAnalysis
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/analysis/experiment_analysis.py", line 42, in <module>
    from ray.tune.experiment import Trial
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/experiment/__init__.py", line 2, in <module>
    from ray.tune.experiment.trial import Trial
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/experiment/trial.py", line 33, in <module>
    from ray.tune.logger import NoopLogger
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/logger/__init__.py", line 10, in <module>
    from ray.tune.logger.tensorboardx import TBXLogger, TBXLoggerCallback
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/logger/tensorboardx.py", line 31, in <module>
    class TBXLogger(Logger):
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/ray/tune/logger/tensorboardx.py", line 41, in TBXLogger
    VALID_NP_HPARAMS = (np.bool8, np.float32, np.float64, np.int32, np.int64)
  File "/Users/bschroeder/RecBole/.venv/lib/python3.9/site-packages/numpy/__init__.py", line 410, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool8'
``` 