### PR TITLE
Fix: run_recbole.py breaks with latest numpy.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch>=1.10.0
-numpy>=1.17.2
+numpy==1.23.1
 scipy>=1.6.0
 hyperopt==0.2.5
 pandas>=1.3.0


### PR DESCRIPTION
From `numpy==1.24` using `bool8` is deprecated. Fixed the `numpy` dependency to version `1.23.1` to avoid having issues with the use of `bool8`.