### PR TITLE
Solve the "AttributeError: module 'numpy' has no attribute 'bool8'. D…

### DIFF
--- a/recbole/trainer/trainer.py
+++ b/recbole/trainer/trainer.py
@@ -580,7 +580,7 @@ class Trainer(AbstractTrainer):
 
         if load_best_model:
             checkpoint_file = model_file or self.saved_model_file
-            checkpoint = torch.load(checkpoint_file, map_location=self.device)
+            checkpoint = torch.load(checkpoint_file, map_location=self.device,weights_only=False)
             self.model.load_state_dict(checkpoint["state_dict"])
             self.model.load_other_parameter(checkpoint.get("other_parameter"))
             message_output = "Loading model structure and parameters from {}".format(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "torch>=1.10.0",
-    "numpy>=1.17.2",
+    "numpy==1.23.5",
     "scipy>=1.6.0",
     "pandas>=1.3.0",
     "tqdm>=4.48.2",


### PR DESCRIPTION
run run_recbole.py  two errors occurred

1. AttributeError: module 'numpy' has no attribute 'bool8'. Did you mean: 'bool'?
2. raceback (most recent call last):
  File "D:\recbole_pr\RecBole-1.2.1\RecBole-1.2.1\run_recbole.py", line 46, in <module>
    run(
  File "D:\recbole_pr\RecBole-1.2.1\RecBole-1.2.1\recbole\quick_start\quick_start.py", line 52, in run
    res = run_recbole(
  File "D:\recbole_pr\RecBole-1.2.1\RecBole-1.2.1\recbole\quick_start\quick_start.py", line 153, in run_recbole
    test_result = trainer.evaluate(
  File "C:\Users\cm\.conda\envs\RecBole\lib\site-packages\torch\utils\_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "D:\recbole_pr\RecBole-1.2.1\RecBole-1.2.1\recbole\trainer\trainer.py", line 583, in evaluate
    checkpoint = torch.load(checkpoint_file, map_location=self.device)
  File "C:\Users\cm\.conda\envs\RecBole\lib\site-packages\torch\serialization.py", line 1470, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
Please file an issue with the following so that we can make `weights_only=True` compatible with your use case: WeightsUnpickler error: Unsupported operand 149

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.

Solution
The purpose is to solve these two errors, 
modify the numpy version and specify the value corresponding to weights_only to be false