### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM pytorch/pytorch:2.9.1-cuda13.0-cudnn9-runtime
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y unzip wget && \
+    pip install --no-cache-dir recbole && \
+    pip install --no-cache-dir --force-reinstall numpy==1.26 && \
+    wget -O /usr/local/bin/run_hyper.py https://github.com/RUCAIBox/RecBole/raw/refs/heads/master/run_hyper.py && \
+    sed -i '1i#! /usr/bin/env python3' /usr/local/bin/run_hyper.py && \
+    wget -O /usr/local/bin/run_recbole.py https://github.com/RUCAIBox/RecBole/raw/refs/heads/master/run_recbole.py && \
+    sed -i '1i#! /usr/bin/env python3' /usr/local/bin/run_recbole.py && \
+    wget -O /usr/local/bin/run_recbole_group.py https://github.com/RUCAIBox/RecBole/raw/refs/heads/master/run_recbole_group.py && \
+    sed -i '1i#! /usr/bin/env python3' /usr/local/bin/run_recbole_group.py && \
+    wget https://github.com/RUCAIBox/RecSysDatasets/archive/refs/heads/master.zip && \
+    unzip master.zip && \
+    mv RecSysDatasets-master /usr/local/bin/RecSysDatasets && \
+    echo "alias run_recbole_convert='python /usr/local/bin/RecSysDatasets/conversion_tools/run.py'" >> ~/.bashrc && \
+    rm -rf master.zip && \
+    chmod a+x /usr/local/bin/run_*.py && \
+    rm -rf /root/.cache /tmp/*


### PR DESCRIPTION
This PR adds a `Dockerfile` for a minimal Docker environment for RecBole with PyTorch + CUDA (and thus GPU acceleration support). In addition to installing RecBole and its dependencies globally, it adds the following items for convenience:

* RecBole's [`run_hyper.py`](https://github.com/RUCAIBox/RecBole/blob/master/run_hyper.py) script (with an added Python shebang so it can be executed by name)
* RecBole's [`run_recbole.py`](https://github.com/RUCAIBox/RecBole/blob/master/run_recbole.py) script (with an added Python shebang so it can be executed by name)
* RecBole's [`run_recbole_group.py`](https://github.com/RUCAIBox/RecBole/blob/master/run_recbole_group.py) script (with an added Python shebang so it can be executed by name)
* The [`RecSysDatasets`](https://github.com/RUCAIBox/RecSysDatasets) repo, with an alias `run_recbole_convert` to execute the [`run.py`](https://github.com/RUCAIBox/RecSysDatasets/blob/master/conversion_tools/run.py) script