### PR TITLE
Fix error handling bugs in url.py makedirs and download_url

### DIFF
--- a/recbole/utils/url.py
+++ b/recbole/utils/url.py
@@ -9,7 +9,6 @@ import urllib.request as ur
 import zipfile
 import os
 import os.path as osp
-import errno
 from logging import getLogger
 
 from tqdm import tqdm
@@ -34,11 +33,7 @@ def decide_download(url):
 
 
 def makedirs(path):
-    try:
-        os.makedirs(osp.expanduser(osp.normpath(path)))
-    except OSError as e:
-        if e.errno != errno.EEXIST and osp.isdir(path):
-            raise e
+    os.makedirs(osp.expanduser(osp.normpath(path)), exist_ok=True)
 
 
 def download_url(url, folder):
@@ -62,27 +57,32 @@ def download_url(url, folder):
     makedirs(folder)
     data = ur.urlopen(url)
 
-    size = int(data.info()["Content-Length"])
-
-    chunk_size = 1024 * 1024
-    num_iter = int(size / chunk_size) + 2
-
-    downloaded_size = 0
-
     try:
-        with open(path, "wb") as f:
-            pbar = tqdm(range(num_iter))
-            for i in pbar:
-                chunk = data.read(chunk_size)
-                downloaded_size += len(chunk)
-                pbar.set_description(
-                    "Downloaded {:.2f} GB".format(float(downloaded_size) / GBFACTOR)
-                )
-                f.write(chunk)
-    except:
-        if os.path.exists(path):
-            os.remove(path)
-        raise RuntimeError("Stopped downloading due to interruption.")
+        size = int(data.info()["Content-Length"])
+
+        chunk_size = 1024 * 1024
+        num_iter = int(size / chunk_size) + 2
+
+        downloaded_size = 0
+
+        try:
+            with open(path, "wb") as f:
+                pbar = tqdm(range(num_iter))
+                for i in pbar:
+                    chunk = data.read(chunk_size)
+                    downloaded_size += len(chunk)
+                    pbar.set_description(
+                        "Downloaded {:.2f} GB".format(
+                            float(downloaded_size) / GBFACTOR
+                        )
+                    )
+                    f.write(chunk)
+        except Exception:
+            if os.path.exists(path):
+                os.remove(path)
+            raise
+    finally:
+        data.close()
 
     return path
 


### PR DESCRIPTION
## Summary

Fixes three related error handling bugs in `recbole/utils/url.py`:

### 1. `makedirs()` silently swallows real OS errors

The except clause has an inverted condition:

```python
except OSError as e:
    if e.errno != errno.EEXIST and osp.isdir(path):
        raise e
```

This means when `errno != EEXIST` (e.g., `PermissionError`) **and** the path doesn't exist as a directory, the error is silently swallowed. The function returns successfully but the directory was never created, causing confusing failures downstream.

**Fix:** Replace with `os.makedirs(exist_ok=True)`, which is the correct Python 3 approach and handles all edge cases properly.

### 2. `download_url()` bare `except:` catches KeyboardInterrupt

The bare `except:` clause catches `KeyboardInterrupt` and `SystemExit`, making it difficult to interrupt a long download with Ctrl+C — the user gets a generic `RuntimeError("Stopped downloading due to interruption.")` instead of a clean exit, and the original traceback is lost.

**Fix:** Use `except Exception:` and re-raise the original exception with `raise` to preserve the traceback.

### 3. `download_url()` leaks the URL connection

The `ur.urlopen(url)` response is never closed, leaking socket/file descriptors. This matters when `download_url` is called repeatedly or when an exception occurs mid-download.

**Fix:** Wrap the download logic in `try/finally` to ensure `data.close()` is always called.

## Test plan

- [x] Verify `makedirs` works for new directories
- [x] Verify `makedirs` is a no-op for existing directories
- [x] Verify `makedirs` raises on permission errors instead of silently failing
- [x] Verify Ctrl+C during download propagates `KeyboardInterrupt` cleanly
- [x] Verify download errors preserve the original exception traceback
- [x] Verify URL connections are closed after download (success or failure)