### PR TITLE
fix: use raise instead of return for ValueError; fix mutable default argument

### DIFF
--- a/recbole/model/context_aware_recommender/kd_dagfm.py
+++ b/recbole/model/context_aware_recommender/kd_dagfm.py
@@ -72,7 +72,7 @@ class KD_DAGFM(ContextRecommender):
         elif self.phase == "distillation" or self.phase == "finetuning":
             return self.student_network.FeatureInteraction(feature)
         else:
-            return ValueError("Phase invalid!")
+            raise ValueError("Phase invalid!")
 
     def forward(self, interaction):
         dagfm_all_embeddings = self.concat_embed_input_fields(

--- a/recbole/utils/utils.py
+++ b/recbole/utils/utils.py
@@ -377,7 +377,7 @@ def get_flops(model, dataset, device, logger, transform, verbose=False):
     return total_ops
 
 
-def list_to_latex(convert_list, bigger_flag=True, subset_columns=[]):
+def list_to_latex(convert_list, bigger_flag=True, subset_columns=None):
     result = {}
     for d in convert_list:
         for key, value in d.items():
@@ -388,6 +388,8 @@ def list_to_latex(convert_list, bigger_flag=True, subset_columns=[]):
 
     df = pd.DataFrame.from_dict(result, orient="index").T
 
+    if subset_columns is None:
+        subset_columns = []
     if len(subset_columns) == 0:
         tex = df.to_latex(index=False)
         return df, tex


### PR DESCRIPTION
## Summary

Two small bug fixes:

- **`recbole/model/context_aware_recommender/kd_dagfm.py` (line 75):** `return ValueError("Phase invalid!")` silently returns an exception object instead of raising it. When `KD_DAGFM.FeatureInteraction` is called with an invalid phase, the error goes completely unnoticed and the caller receives a `ValueError` object as if it were a valid result. Changed to `raise ValueError(...)`.

- **`recbole/utils/utils.py` (line 380):** `list_to_latex` uses a mutable default argument `subset_columns=[]`. Mutable defaults are shared across all calls to the function, which can lead to subtle, hard-to-reproduce bugs if the list is ever mutated. Changed to the standard `subset_columns=None` pattern with initialisation inside the function body.

## Changes

| File | Fix |
|------|-----|
| `recbole/model/context_aware_recommender/kd_dagfm.py` | `return ValueError(...)` → `raise ValueError(...)` |
| `recbole/utils/utils.py` | `subset_columns=[]` → `subset_columns=None` with guard |