### PR TITLE
Fix AttributeError in eval_collector for non-tensor metric values

### DIFF
--- a/recbole/evaluator/collector.py
+++ b/recbole/evaluator/collector.py
@@ -224,7 +224,9 @@ class Collector(object):
         And reset some of outdated resource.
         """
         for key in self.data_struct._data_dict:
-            self.data_struct._data_dict[key] = self.data_struct._data_dict[key].cpu()
+            value = self.data_struct._data_dict[key]
+            if isinstance(value, torch.Tensor):
+                self.data_struct._data_dict[key] = value.cpu()
         returned_struct = copy.deepcopy(self.data_struct)
         for key in ["rec.topk", "rec.meanrank", "rec.score", "rec.items", "data.label"]:
             if key in self.data_struct:


### PR DESCRIPTION
## Summary
- Fixes #2194: `get_data_struct()` in `Collector` calls `.cpu()` on every value in `_data_dict`, but non-accuracy metrics (`AveragePopularity`, `GiniIndex`, `ShannonEntropy`) store plain integers and `Counter` objects
- Adds a `isinstance(value, torch.Tensor)` check before calling `.cpu()`

## Root Cause
The `data_collect` method registers non-tensor values like `data.num_items` (int), `data.count_items` (Counter), etc. When `get_data_struct()` iterates over all values and calls `.cpu()`, these non-tensor types raise `AttributeError: 'int' object has no attribute 'cpu'`.

## Test plan
- [ ] Verify existing tests pass
- [ ] Test with metrics that collect non-tensor values (AveragePopularity, GiniIndex, ShannonEntropy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)