### PR TITLE
Fix infinite loop in _neg_sample when item_set covers all items

### DIFF
--- a/recbole/data/transform.py
+++ b/recbole/data/transform.py
@@ -65,6 +65,22 @@ class MaskItemSequence:
         self.config = config
 
     def _neg_sample(self, item_set, n_items):
+        """Sample a negative item that is not in the given item_set.
+
+        When the item_set covers all possible items (1 to n_items - 1),
+        negative sampling is impossible. In this case, return 0 (padding
+        index) to avoid an infinite loop.
+
+        Args:
+            item_set: Collection of item ids that should be excluded.
+            n_items: Total number of items (including padding item 0).
+
+        Returns:
+            A sampled negative item id, or 0 if no valid negative item exists.
+        """
+        item_set = set(item_set)
+        if len(item_set) >= n_items - 1:
+            return 0
         item = random.randint(1, n_items - 1)
         while item in item_set:
             item = random.randint(1, n_items - 1)


### PR DESCRIPTION
## Summary
- Fixes #2193: `_neg_sample` in `MaskItemSequence` enters an infinite loop when a user's interaction history covers all possible item IDs (1 to `n_items - 1`)
- Adds a guard check before the sampling loop: returns 0 (padding index) when no valid negative sample exists
- Converts `item_set` to a `set` for O(1) membership lookups

## Root Cause
When `MAX_ITEM_LIST_LENGTH` exceeds the number of unique items in the dataset (e.g., 100 vs 10 items), a user's masked sequence can contain all valid item IDs. The `while item in item_set` loop then never terminates.

## Test plan
- [ ] Verify existing tests pass
- [ ] Test with a small dataset where a user's sequence contains all item IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)